### PR TITLE
docs(cli): clarify user automation caveats

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -495,6 +495,15 @@ curl -X GET "http://<proxy>/api/toolbox/<sandbox-id>/toolbox/files" \
 The `cmd/user` binary provides a reference client for both on-chain and proxy operations.
 Set `USER_KEY=0x<private-key>` as an environment variable to avoid passing `--key` every time.
 
+For local testing, avoid typing private keys directly into long shell commands.
+Prefer a local env file that is not committed:
+
+```bash
+printf 'export USER_KEY=0x<key>\n' > .env.user
+chmod 600 .env.user
+source .env.user
+```
+
 ### Chain Subcommands
 
 #### `balance` — Check account balance
@@ -613,6 +622,16 @@ USER_KEY=0x<key> go run ./cmd/user/ exec \
 
 Output: stdout/stderr of the command. Exits with the command's exit code.
 
+For shell features such as `&&`, pipes, redirects, globs, or environment
+expansion, wrap the command explicitly:
+
+```bash
+USER_KEY=0x<key> go run ./cmd/user/ exec \
+  --api http://<proxy>:8080 \
+  --id <sandbox-id> \
+  --cmd "sh -lc 'mkdir -p /tmp/demo && ls -ld /tmp/demo'"
+```
+
 #### `toolbox` — Arbitrary toolbox API call
 
 ```bash
@@ -639,28 +658,42 @@ USER_KEY=0x<key> go run ./cmd/user/ toolbox --api http://<proxy>:8080 --id <id> 
 
 #### `ssh-access` — Get temporary SSH access token
 
-Token valid for 60 minutes. The token is used as the **SSH username** (no password needed).
+Token valid for 60 minutes. The CLI prints the SSH command to stdout and the
+temporary password token to stderr. Quote the token when passing it to
+automation, because it may contain shell metacharacters.
 
 ```bash
 USER_KEY=0x<key> go run ./cmd/user/ ssh-access \
   --api http://<proxy>:8080 \
   --id <sandbox-id>
-# → prints: ssh -p 2222 TOKEN@<host>
+# stdout: ssh -p 2222 <user>@<host>
+# stderr: Password: <token>
 ```
 
 Use for direct SSH or rsync sync:
 ```bash
-SSH_CMD=$(USER_KEY=0x<key> go run ./cmd/user/ ssh-access --api http://<proxy>:8080 --id <id> 2>/dev/null)
+SSH_OUTPUT=$(USER_KEY=0x<key> go run ./cmd/user/ ssh-access --api http://<proxy>:8080 --id <id> 2>&1)
+SSH_CMD=$(printf '%s\n' "$SSH_OUTPUT" | grep '^ssh ')
+TOKEN=$(printf '%s\n' "$SSH_OUTPUT" | awk '/^Password:/ {print $2}')
 PORT=$(echo $SSH_CMD | awk '{print $3}')
 USER_HOST=$(echo $SSH_CMD | awk '{print $4}')
 
 # Direct SSH
 ssh -p $PORT -o StrictHostKeyChecking=no $USER_HOST
+```
 
+Some provider SSH gateways may not support `scp` or the rsync remote protocol.
+Test with a small file before relying on rsync for project sync:
+
+```bash
 # Rsync local directory to sandbox
-rsync -avz --delete -e "ssh -p $PORT -o StrictHostKeyChecking=no" \
+sshpass -p "$TOKEN" rsync -avz --delete -e "ssh -p $PORT -o StrictHostKeyChecking=no" \
   ./my-project/ "${USER_HOST}:/home/daytona/project/"
 ```
+
+If rsync closes the connection or hangs, use the toolbox `files/upload` endpoint
+or `cmd/user exec` with a verified archive upload until first-class CLI upload
+support is available.
 
 ---
 

--- a/CLI.md
+++ b/CLI.md
@@ -9,6 +9,17 @@ Two command-line tools are provided for operators and users:
 
 Private keys can be passed via `--key` flag or environment variable (`PROVIDER_KEY` / `USER_KEY`). The `0x` prefix is optional.
 
+For local testing, avoid typing private keys directly into long shell commands.
+Prefer a local env file that is not committed:
+
+```bash
+printf 'export USER_KEY=0x<hex>\n' > .env.user
+chmod 600 .env.user
+source .env.user
+```
+
+Keep `.env.user` out of git. Use placeholders only in shared logs, docs, and issues.
+
 ---
 
 ## `cmd/provider` — Provider Operations


### PR DESCRIPTION
## Summary / What changed

- Document a safer local env file pattern for `USER_KEY` instead of typing keys into long shell commands.
- Clarify that compound `exec` commands should be wrapped with `sh -lc`.
- Fix the `ssh-access` docs to match current CLI output: SSH command on stdout, temporary password token on stderr.
- Add a warning that some SSH gateways may not support `scp` or rsync protocol, and suggest toolbox upload as fallback.

## Why

I hit these issues while using the CLI for automated sandbox smoke tests. The sandbox flow worked, but the docs made a few automation paths look more direct than they are today.

This PR keeps the current behavior. It only updates docs so new users have a safer and more reliable path.

## Tests

Docs-only change.

I checked the changed examples for placeholder-only key usage and no real secrets.

## Real-world validation

Tested against a live 0G Sandbox provider on 2026-04-22 using repo SHA `407ba1c3dc41435e7ec5c82ab58feb380abe9430`.

Validated flows included `providers`, `/healthz`, `/info`, `snapshots`, `deposit`, `acknowledge`, `create`, `exec`, upload through `exec`, and `delete`.

## Issue

Related to #37.
