### PR TITLE
feat(cli): add automation-friendly user output

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -577,14 +577,21 @@ USER_KEY=0x<key> go run ./cmd/user/ create \
   [--class    small|medium|large] \
   [--cpu      <cores>] \
   [--memory   <gb>] \
-  [--disk     <gb>]
+  [--disk     <gb>] \
+  [--wait] [--timeout 120] [--json]
 ```
+
+Use `--wait` for automation that needs the sandbox to be ready before the next
+`exec` call. With `--json`, the command prints only the sandbox JSON object.
 
 #### `list` — List sandboxes
 
 ```bash
-USER_KEY=0x<key> go run ./cmd/user/ list --api http://<proxy>:8080
+USER_KEY=0x<key> go run ./cmd/user/ list --api http://<proxy>:8080 [--json]
 ```
+
+Without `--json`, the CLI keeps the human-readable output. With `--json`, it
+prints one JSON array.
 
 #### `start` — Start a stopped sandbox
 
@@ -617,10 +624,13 @@ USER_KEY=0x<key> go run ./cmd/user/ exec \
   --api http://<proxy>:8080 \
   --id <sandbox-id> \
   --cmd "python3 -c \"print('hello')\"" \
-  [--timeout 30]                    # seconds, default 30
+  [--timeout 30] \                  # seconds, default 30
+  [--raw | --json]
 ```
 
-Output: stdout/stderr of the command. Exits with the command's exit code.
+Default output is a human-readable ANSI frame. Use `--raw` to print only the
+command result, or `--json` to print the toolbox response as JSON. The CLI exits
+with the command's exit code in all modes.
 
 For shell features such as `&&`, pipes, redirects, globs, or environment
 expansion, wrap the command explicitly:
@@ -665,10 +675,14 @@ automation, because it may contain shell metacharacters.
 ```bash
 USER_KEY=0x<key> go run ./cmd/user/ ssh-access \
   --api http://<proxy>:8080 \
-  --id <sandbox-id>
+  --id <sandbox-id> \
+  [--json]
 # stdout: ssh -p 2222 <user>@<host>
 # stderr: Password: <token>
 ```
+
+Use `--json` when a script needs explicit `sshCommand`, `token`, and `expiresAt`
+fields without parsing stdout and stderr.
 
 Use for direct SSH or rsync sync:
 ```bash

--- a/CLI.md
+++ b/CLI.md
@@ -514,7 +514,8 @@ go run ./cmd/user/ create \
   [--class     small|medium|large] \
   [--cpu       <cores>] \
   [--memory    <gb>] \
-  [--disk      <gb>]
+  [--disk      <gb>] \
+  [--wait] [--timeout <seconds>] [--json]
 ```
 
 | Flag | Default | Description |
@@ -528,6 +529,9 @@ go run ./cmd/user/ create \
 | `--memory` | — | Memory in GB (overrides `--class`) |
 | `--disk` | — | Disk in GB (overrides `--class`) |
 | `--sealed` | `false` | Create a sealed sandbox: injects TEE attestation, blocks SSH and toolbox access |
+| `--wait` | `false` | Wait until the sandbox reaches `state=started` |
+| `--timeout` | `120` | Wait timeout in seconds, used with `--wait` |
+| `--json` | `false` | Print machine-readable JSON |
 
 **Example**
 
@@ -548,7 +552,8 @@ List your sandboxes (filtered by owner — you only see your own).
 ```bash
 go run ./cmd/user/ list \
   --api  <0g-sandbox-url> \
-  [--key <hex>]
+  [--key <hex>] \
+  [--json]
 ```
 
 **Example**
@@ -556,6 +561,8 @@ go run ./cmd/user/ list \
 ```bash
 USER_KEY=0x<hex> go run ./cmd/user/ list --api http://<provider-host>:8080
 ```
+
+Use `--json` to print one JSON array for automation.
 
 ```json
 {

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -392,6 +392,9 @@ func runCreate(args []string) {
 	fs.Var(&envArgs, "env",                                   "Env var KEY=VAL injected into container; repeatable")
 	_ = fs.Parse(args)
 
+	if *wait && *timeout <= 0 {
+		fatalf("--timeout must be greater than zero")
+	}
 	if *class != "" && *class != "small" && *class != "medium" && *class != "large" {
 		fatalf("--class must be one of: small, medium, large")
 	}
@@ -467,9 +470,6 @@ func runCreate(args []string) {
 		id, ok := stringField(result, "id")
 		if !ok {
 			fatalf("create response did not include sandbox id")
-		}
-		if *timeout <= 0 {
-			fatalf("--timeout must be greater than zero")
 		}
 		if !*jsonOut {
 			fmt.Printf("Created sandbox: %s\n", prettyJSON(result))
@@ -927,10 +927,20 @@ func runListSnapshots(args []string) {
 var sandboxWaitPollInterval = 2 * time.Second
 
 func waitForSandboxStarted(privKey *ecdsa.PrivateKey, apiURL, id string, timeout time.Duration) map[string]any {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	deadline := time.Now().Add(timeout)
 	lastState := ""
+waitLoop:
 	for {
-		sb := getSandbox(privKey, apiURL, id)
+		sb, err := getSandbox(ctx, privKey, apiURL, id)
+		if err != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			fatalf("get sandbox: %v", err)
+		}
 		if state, ok := stringField(sb, "state"); ok {
 			lastState = state
 			stateLower := strings.ToLower(state)
@@ -941,22 +951,33 @@ func waitForSandboxStarted(privKey *ecdsa.PrivateKey, apiURL, id string, timeout
 				fatalf("sandbox %s entered terminal state %q", id, state)
 			}
 		}
-		if time.Now().After(deadline) {
-			if lastState == "" {
-				lastState = "unknown"
-			}
-			fatalf("timed out waiting for sandbox %s to reach state=started (last state: %s)", id, lastState)
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
 		}
-		time.Sleep(sandboxWaitPollInterval)
+		sleep := sandboxWaitPollInterval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		select {
+		case <-ctx.Done():
+			break waitLoop
+		case <-time.After(sleep):
+		}
 	}
+	if lastState == "" {
+		lastState = "unknown"
+	}
+	fatalf("timed out waiting for sandbox %s to reach state=started (last state: %s)", id, lastState)
+	return nil
 }
 
-func getSandbox(privKey *ecdsa.PrivateKey, apiURL, id string) map[string]any {
+func getSandbox(ctx context.Context, privKey *ecdsa.PrivateKey, apiURL, id string) (map[string]any, error) {
 	msg, sig, walletAddr := signRequest(privKey, "list", id, json.RawMessage(`{}`))
 
-	req, err := http.NewRequest(http.MethodGet, apiURL+"/api/sandbox/"+id, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/api/sandbox/"+id, nil)
 	if err != nil {
-		fatalf("build request: %v", err)
+		return nil, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("X-Wallet-Address", walletAddr)
 	req.Header.Set("X-Signed-Message", msg)
@@ -964,20 +985,20 @@ func getSandbox(privKey *ecdsa.PrivateKey, apiURL, id string) map[string]any {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fatalf("get sandbox: %v", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 300 {
-		fatalf("get sandbox: HTTP %d: %s", resp.StatusCode, respBody)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
 	}
 
 	var result map[string]any
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		fatalf("parse sandbox response: %v", err)
+		return nil, fmt.Errorf("parse sandbox response: %w", err)
 	}
-	return result
+	return result, nil
 }
 
 func stringField(m map[string]any, key string) (string, bool) {

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -524,6 +524,9 @@ func runList(args []string) {
 		fmt.Println(string(respBody))
 		return
 	}
+	if result == nil {
+		result = []any{}
+	}
 	if *jsonOut {
 		fmt.Println(prettyJSON(result))
 		return

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -385,6 +385,9 @@ func runCreate(args []string) {
 	disk     := fs.Int("disk",        0,                      "Disk in GB (optional, overrides class)")
 	sealed   := fs.Bool("sealed",     false,                  "Create a sealed sandbox (blocks SSH and toolbox access)")
 	sealID   := fs.String("seal-id",  "",                     "Optional caller-chosen seal_id (64 hex chars); random if unset")
+	wait     := fs.Bool("wait",       false,                  "Wait until the sandbox reaches state=started")
+	timeout  := fs.Int("timeout",     120,                    "Wait timeout in seconds (used with --wait)")
+	jsonOut  := fs.Bool("json",       false,                  "Print machine-readable JSON")
 	var envArgs multiString
 	fs.Var(&envArgs, "env",                                   "Env var KEY=VAL injected into container; repeatable")
 	_ = fs.Parse(args)
@@ -460,6 +463,28 @@ func runCreate(args []string) {
 
 	var result map[string]any
 	json.Unmarshal(respBody, &result) //nolint:errcheck
+	if *wait {
+		id, ok := stringField(result, "id")
+		if !ok {
+			fatalf("create response did not include sandbox id")
+		}
+		if *timeout <= 0 {
+			fatalf("--timeout must be greater than zero")
+		}
+		if !*jsonOut {
+			fmt.Printf("Created sandbox: %s\n", prettyJSON(result))
+			fmt.Printf("Waiting for sandbox %s to reach state=started...\n", id)
+		}
+		result = waitForSandboxStarted(privKey, *apiURL, id, time.Duration(*timeout)*time.Second)
+	}
+	if *jsonOut {
+		fmt.Println(prettyJSON(result))
+		return
+	}
+	if *wait {
+		fmt.Printf("Sandbox ready: %s\n", prettyJSON(result))
+		return
+	}
 	fmt.Printf("Created sandbox: %s\n", prettyJSON(result))
 }
 
@@ -469,6 +494,7 @@ func runList(args []string) {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 	apiURL  := fs.String("api", "http://localhost:8080", "Billing proxy URL")
 	keyHex  := fs.String("key", "",                     "User private key (hex); or set USER_KEY env")
+	jsonOut := fs.Bool("json", false, "Print machine-readable JSON")
 	_ = fs.Parse(args)
 
 	privKey := mustLoadKey(*keyHex)
@@ -496,6 +522,10 @@ func runList(args []string) {
 	var result []any
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		fmt.Println(string(respBody))
+		return
+	}
+	if *jsonOut {
+		fmt.Println(prettyJSON(result))
 		return
 	}
 	if len(result) == 0 {
@@ -589,6 +619,8 @@ func runExec(args []string) {
 	id      := fs.String("id",      "",                     "Sandbox ID (required)")
 	command := fs.String("cmd",     "",                     "Shell command to run (required)")
 	timeout := fs.Int("timeout",    30,                     "Timeout in seconds")
+	rawOut  := fs.Bool("raw",       false,                  "Print command output without ANSI framing")
+	jsonOut := fs.Bool("json",      false,                  "Print machine-readable JSON")
 	_ = fs.Parse(args)
 
 	if *id == "" {
@@ -596,6 +628,9 @@ func runExec(args []string) {
 	}
 	if *command == "" {
 		fatalf("--cmd is required")
+	}
+	if *rawOut && *jsonOut {
+		fatalf("--raw and --json are mutually exclusive")
 	}
 
 	privKey := mustLoadKey(*keyHex)
@@ -631,7 +666,13 @@ func runExec(args []string) {
 		fmt.Print(string(respBody))
 		return
 	}
-	printSandboxOutput(*id, *command, result.Result, result.ExitCode)
+	if *jsonOut {
+		fmt.Println(prettyJSON(result))
+	} else if *rawOut {
+		fmt.Print(result.Result)
+	} else {
+		printSandboxOutput(*id, *command, result.Result, result.ExitCode)
+	}
 	if result.ExitCode != 0 {
 		os.Exit(result.ExitCode)
 	}
@@ -780,7 +821,8 @@ func runSSHAccess(args []string) {
 	fs := flag.NewFlagSet("ssh-access", flag.ExitOnError)
 	apiURL := fs.String("api", "http://localhost:8080", "Billing proxy URL")
 	keyHex := fs.String("key", "", "User private key (hex); or set USER_KEY env")
-	id     := fs.String("id",  "", "Sandbox ID (required)")
+	id      := fs.String("id",  "", "Sandbox ID (required)")
+	jsonOut := fs.Bool("json", false, "Print machine-readable JSON")
 	_ = fs.Parse(args)
 
 	if *id == "" {
@@ -823,6 +865,12 @@ func runSSHAccess(args []string) {
 	apiHost := strings.TrimPrefix(strings.TrimPrefix(*apiURL, "https://"), "http://")
 	apiHost = strings.Split(apiHost, ":")[0]
 	sshCmd := strings.ReplaceAll(result.SSHCommand, "localhost", apiHost)
+	result.SSHCommand = sshCmd
+
+	if *jsonOut {
+		fmt.Println(prettyJSON(result))
+		return
+	}
 
 	fmt.Println(sshCmd)
 	if result.ExpiresAt != "" {
@@ -872,6 +920,67 @@ func runListSnapshots(args []string) {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+var sandboxWaitPollInterval = 2 * time.Second
+
+func waitForSandboxStarted(privKey *ecdsa.PrivateKey, apiURL, id string, timeout time.Duration) map[string]any {
+	deadline := time.Now().Add(timeout)
+	lastState := ""
+	for {
+		sb := getSandbox(privKey, apiURL, id)
+		if state, ok := stringField(sb, "state"); ok {
+			lastState = state
+			stateLower := strings.ToLower(state)
+			if stateLower == "started" {
+				return sb
+			}
+			if strings.Contains(stateLower, "error") || strings.Contains(stateLower, "fail") {
+				fatalf("sandbox %s entered terminal state %q", id, state)
+			}
+		}
+		if time.Now().After(deadline) {
+			if lastState == "" {
+				lastState = "unknown"
+			}
+			fatalf("timed out waiting for sandbox %s to reach state=started (last state: %s)", id, lastState)
+		}
+		time.Sleep(sandboxWaitPollInterval)
+	}
+}
+
+func getSandbox(privKey *ecdsa.PrivateKey, apiURL, id string) map[string]any {
+	msg, sig, walletAddr := signRequest(privKey, "list", id, json.RawMessage(`{}`))
+
+	req, err := http.NewRequest(http.MethodGet, apiURL+"/api/sandbox/"+id, nil)
+	if err != nil {
+		fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Wallet-Address", walletAddr)
+	req.Header.Set("X-Signed-Message", msg)
+	req.Header.Set("X-Wallet-Signature", sig)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fatalf("get sandbox: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		fatalf("get sandbox: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		fatalf("parse sandbox response: %v", err)
+	}
+	return result
+}
+
+func stringField(m map[string]any, key string) (string, bool) {
+	v, ok := m[key].(string)
+	return v, ok && v != ""
+}
 
 // signRequest builds the three auth headers required by the billing proxy.
 // Returns (X-Signed-Message value, X-Wallet-Signature value, X-Wallet-Address value).

--- a/cmd/user/main_test.go
+++ b/cmd/user/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestStringField(t *testing.T) {
+	t.Parallel()
+
+	got, ok := stringField(map[string]any{"id": "sb-1"}, "id")
+	if !ok || got != "sb-1" {
+		t.Fatalf("stringField() = %q, %v; want sb-1, true", got, ok)
+	}
+
+	if _, ok := stringField(map[string]any{"id": 123}, "id"); ok {
+		t.Fatal("stringField() accepted non-string value")
+	}
+
+	if _, ok := stringField(map[string]any{"id": ""}, "id"); ok {
+		t.Fatal("stringField() accepted empty string")
+	}
+}
+
+func TestWaitForSandboxStartedPollsUntilStarted(t *testing.T) {
+	oldPoll := sandboxWaitPollInterval
+	sandboxWaitPollInterval = time.Millisecond
+	defer func() { sandboxWaitPollInterval = oldPoll }()
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s; want GET", r.Method)
+		}
+		if r.URL.Path != "/api/sandbox/sb-1" {
+			t.Errorf("path = %s; want /api/sandbox/sb-1", r.URL.Path)
+		}
+		for _, header := range []string{"X-Wallet-Address", "X-Signed-Message", "X-Wallet-Signature"} {
+			if r.Header.Get(header) == "" {
+				t.Errorf("missing header %s", header)
+			}
+		}
+
+		state := "creating"
+		if atomic.AddInt32(&calls, 1) >= 2 {
+			state = "started"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "sb-1",
+			"state": state,
+		})
+	}))
+	defer srv.Close()
+
+	got := waitForSandboxStarted(key, srv.URL, "sb-1", time.Second)
+	if state, _ := stringField(got, "state"); state != "started" {
+		t.Fatalf("state = %q; want started", state)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d; want 2", calls)
+	}
+}


### PR DESCRIPTION
## Summary / What changed

- Add `cmd/user create --wait --timeout --json` for automation that needs a ready sandbox before running `exec`.
- Add `cmd/user list --json` so scripts can read one JSON array.
- Add `cmd/user exec --raw` and `cmd/user exec --json` while keeping the current ANSI output as default.
- Add `cmd/user ssh-access --json` so scripts do not need to parse stdout and stderr.
- Harden `create --wait` timeout handling so invalid timeouts fail before sandbox creation, and polling HTTP calls use the same timeout context.
- Add focused tests for the sandbox wait polling helper.

## Why

I used the CLI for live sandbox smoke tests and benchmark automation. The current human output works for manual use, but scripts need stable JSON and raw command output.

The main race was `create` returning while the sandbox was still `creating`. `--wait` gives scripts a reliable ready gate. The timeout guard also avoids creating a sandbox and then failing locally when automation passes an invalid timeout.

## Preserved guardrails

Default output stays the same for existing users. The new modes are opt-in.

This PR does not change authentication, billing, proxy behavior, sandbox ownership checks, or sealed sandbox rules.

## Tests

```bash
go test ./cmd/user ./internal/proxy ./internal/auth
git diff --check
cmd/user create --wait --timeout 0 --api http://127.0.0.1:9
```

The invalid-timeout command exits with `--timeout must be greater than zero` before any network request.

I also checked the touched files for real keys, generated footers, and co-author trailers.

## Real-world validation

The need for these flags came from a live smoke test on 2026-04-22 against repo SHA `407ba1c3dc41435e7ec5c82ab58feb380abe9430`.

Validated flows included `providers`, `/healthz`, `/info`, `snapshots`, `deposit`, `acknowledge`, `create`, `exec`, upload through `exec`, and `delete`.

## Issue

Stacked on #38 because the docs touch the same CLI reference sections.
