### PR TITLE
feat(cli): add sandbox file transfer commands

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -642,6 +642,36 @@ USER_KEY=0x<key> go run ./cmd/user/ exec \
   --cmd "sh -lc 'mkdir -p /tmp/demo && ls -ld /tmp/demo'"
 ```
 
+#### `upload` — Upload a local file
+
+Uploads one local file through the toolbox `files/upload` endpoint. The CLI
+sends a `multipart/form-data` request and passes the remote path as the toolbox
+`path` query parameter.
+
+```bash
+USER_KEY=0x<key> go run ./cmd/user/ upload \
+  --api http://<proxy>:8080 \
+  --id <sandbox-id> \
+  --src ./local-file.txt \
+  --dst /home/daytona/project/local-file.txt \
+  [--json]
+```
+
+#### `download` — Download a remote file
+
+Downloads one file through the toolbox `files/download` endpoint. The response
+body is written as raw file bytes. The local destination is not overwritten
+unless `--overwrite` is passed.
+
+```bash
+USER_KEY=0x<key> go run ./cmd/user/ download \
+  --api http://<proxy>:8080 \
+  --id <sandbox-id> \
+  --src /home/daytona/project/result.txt \
+  --dst ./result.txt \
+  [--overwrite] [--json]
+```
+
 #### `toolbox` — Arbitrary toolbox API call
 
 ```bash

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -735,9 +735,9 @@ sshpass -p "$TOKEN" rsync -avz --delete -e "ssh -p $PORT -o StrictHostKeyCheckin
   ./my-project/ "${USER_HOST}:/home/daytona/project/"
 ```
 
-If rsync closes the connection or hangs, use the toolbox `files/upload` endpoint
-or `cmd/user exec` with a verified archive upload until first-class CLI upload
-support is available.
+If rsync closes the connection or hangs, use `cmd/user upload` and
+`cmd/user download`, which call the toolbox file APIs without relying on SSH
+file-transfer protocol support.
 
 ---
 

--- a/CLI.md
+++ b/CLI.md
@@ -608,6 +608,39 @@ go run ./cmd/user/ delete \
 
 ---
 
+#### `upload`
+
+Upload one local file to a sandbox through the toolbox API.
+
+```bash
+go run ./cmd/user/ upload \
+  --api  <0g-sandbox-url> \
+  --id   <sandbox-id> \
+  --src  <local-file> \
+  --dst  <remote-file> \
+  [--key <hex>] \
+  [--json]
+```
+
+---
+
+#### `download`
+
+Download one sandbox file through the toolbox API. Existing local files are not
+overwritten unless `--overwrite` is passed.
+
+```bash
+go run ./cmd/user/ download \
+  --api  <0g-sandbox-url> \
+  --id   <sandbox-id> \
+  --src  <remote-file> \
+  --dst  <local-file> \
+  [--key <hex>] \
+  [--overwrite] [--json]
+```
+
+---
+
 #### `snapshots`
 
 List snapshots available for use when creating sandboxes.

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -710,33 +710,71 @@ func runUpload(args []string) {
 		fatalf("--dst is required")
 	}
 
-	data, err := os.ReadFile(*src)
+	file, err := os.Open(*src)
 	if err != nil {
-		fatalf("read %s: %v", *src, err)
+		fatalf("open %s: %v", *src, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		fatalf("stat %s: %v", *src, err)
+	}
+	if info.IsDir() {
+		_ = file.Close()
+		fatalf("%s is a directory", *src)
 	}
 
 	privKey := mustLoadKey(*keyHex)
-	var bodyBuf bytes.Buffer
-	writer := multipart.NewWriter(&bodyBuf)
-	part, err := writer.CreateFormFile("file", filepath.Base(*src))
-	if err != nil {
-		fatalf("create multipart file: %v", err)
-	}
-	if _, err := part.Write(data); err != nil {
-		fatalf("write multipart file: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		fatalf("close multipart writer: %v", err)
-	}
+	bodyReader, bodyWriter := io.Pipe()
+	writer := multipart.NewWriter(bodyWriter)
+	uploadDone := make(chan error, 1)
+	go func() {
+		defer file.Close()
+		var err error
+		defer func() {
+			if err != nil {
+				_ = bodyWriter.CloseWithError(err)
+			} else {
+				_ = bodyWriter.Close()
+			}
+			uploadDone <- err
+		}()
+		part, err := writer.CreateFormFile("file", filepath.Base(*src))
+		if err != nil {
+			return
+		}
+		if _, err = io.Copy(part, file); err != nil {
+			return
+		}
+		err = writer.Close()
+	}()
 
 	action := "files/upload?path=" + url.QueryEscape(*dst)
-	respBody, _ := signedToolboxRequest(privKey, *apiURL, *id, http.MethodPost, action, bodyBuf.Bytes(), writer.FormDataContentType())
+	resp, err := signedToolboxHTTPResponse(privKey, *apiURL, *id, http.MethodPost, action, bodyReader, writer.FormDataContentType())
+	if err != nil {
+		_ = bodyReader.CloseWithError(err)
+		fatalf("%v", err)
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		_ = resp.Body.Close()
+		fatalf("read upload response: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		fatalf("close upload response: %v", err)
+	}
+	if err := <-uploadDone; err != nil {
+		fatalf("upload %s: %v", *src, err)
+	}
 
 	if *jsonOut {
-		fmt.Println(prettyJSON(json.RawMessage(respBody)))
+		fmt.Println(prettyJSON(map[string]any{
+			"src":   *src,
+			"dst":   *dst,
+			"bytes": info.Size(),
+		}))
 		return
 	}
-	fmt.Printf("Uploaded %s to %s (%d bytes)\n", *src, *dst, len(data))
+	fmt.Printf("Uploaded %s to %s (%d bytes)\n", *src, *dst, info.Size())
 }
 
 // ── download ─────────────────────────────────────────────────────────────────
@@ -761,41 +799,82 @@ func runDownload(args []string) {
 	if *dst == "" {
 		fatalf("--dst is required")
 	}
-	if _, err := os.Stat(*dst); err == nil && !*overwrite {
-		fatalf("%s already exists; pass --overwrite to replace it", *dst)
-	} else if err != nil && !os.IsNotExist(err) {
-		fatalf("stat %s: %v", *dst, err)
-	}
-
 	privKey := mustLoadKey(*keyHex)
+
 	action := "files/download?path=" + url.QueryEscape(*src)
-	respBody, contentType := signedToolboxRequest(privKey, *apiURL, *id, http.MethodGet, action, nil, "")
-	data := respBody
-	if strings.Contains(strings.ToLower(contentType), "application/json") {
-		var err error
-		data, err = downloadedFileContent(respBody)
+	resp, err := signedToolboxHTTPResponse(privKey, *apiURL, *id, http.MethodGet, action, nil, "")
+	if err != nil {
+		fatalf("%v", err)
+	}
+	defer resp.Body.Close()
+
+	var written int64
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "application/json") {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fatalf("read download response: %v", err)
+		}
+		data, err := downloadedFileContent(respBody)
 		if err != nil {
 			fatalf("parse download response: %v", err)
 		}
-	}
-	if dir := filepath.Dir(*dst); dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			fatalf("create destination directory: %v", err)
+		out := openDownloadDestination(*dst, *overwrite)
+		n, err := out.Write(data)
+		if err != nil {
+			_ = out.Close()
+			fatalf("write %s: %v", *dst, err)
 		}
-	}
-	if err := os.WriteFile(*dst, data, 0644); err != nil {
-		fatalf("write %s: %v", *dst, err)
+		if n != len(data) {
+			_ = out.Close()
+			fatalf("write %s: short write", *dst)
+		}
+		if err := out.Close(); err != nil {
+			fatalf("write %s: %v", *dst, err)
+		}
+		written = int64(n)
+	} else {
+		out := openDownloadDestination(*dst, *overwrite)
+		written, err = io.Copy(out, resp.Body)
+		if err != nil {
+			_ = out.Close()
+			fatalf("write %s: %v", *dst, err)
+		}
+		if err := out.Close(); err != nil {
+			fatalf("write %s: %v", *dst, err)
+		}
 	}
 
 	if *jsonOut {
 		fmt.Println(prettyJSON(map[string]any{
 			"src":   *src,
 			"dst":   *dst,
-			"bytes": len(data),
+			"bytes": written,
 		}))
 		return
 	}
-	fmt.Printf("Downloaded %s to %s (%d bytes)\n", *src, *dst, len(data))
+	fmt.Printf("Downloaded %s to %s (%d bytes)\n", *src, *dst, written)
+}
+
+func openDownloadDestination(dst string, overwrite bool) *os.File {
+	if dir := filepath.Dir(dst); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fatalf("create destination directory: %v", err)
+		}
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if overwrite {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+	out, err := os.OpenFile(dst, flags, 0644)
+	if os.IsExist(err) && !overwrite {
+		fatalf("%s already exists; pass --overwrite to replace it", dst)
+	}
+	if err != nil {
+		fatalf("open %s: %v", dst, err)
+	}
+	return out
 }
 
 // printSandboxOutput renders sandbox output in a bordered box with ANSI colors.
@@ -1123,17 +1202,13 @@ func stringField(m map[string]any, key string) (string, bool) {
 	return v, ok && v != ""
 }
 
-func signedToolboxRequest(privKey *ecdsa.PrivateKey, apiURL, id, method, action string, body []byte, contentType string) ([]byte, string) {
+func signedToolboxHTTPResponse(privKey *ecdsa.PrivateKey, apiURL, id, method, action string, body io.Reader, contentType string) (*http.Response, error) {
 	msg, sig, walletAddr := signRequest(privKey, "toolbox", id, json.RawMessage(`{}`))
 
 	url := apiURL + "/api/toolbox/" + id + "/toolbox/" + strings.TrimPrefix(action, "/")
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequest(method, url, bodyReader)
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		fatalf("build request: %v", err)
+		return nil, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("X-Wallet-Address", walletAddr)
 	req.Header.Set("X-Signed-Message", msg)
@@ -1147,14 +1222,29 @@ func signedToolboxRequest(privKey *ecdsa.PrivateKey, apiURL, id, method, action 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fatalf("toolbox: %v", err)
+		return nil, fmt.Errorf("toolbox: %w", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("toolbox: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+	return resp, nil
+}
+
+func signedToolboxRequest(privKey *ecdsa.PrivateKey, apiURL, id, method, action string, body []byte, contentType string) ([]byte, string) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	resp, err := signedToolboxHTTPResponse(privKey, apiURL, id, method, action, bodyReader, contentType)
+	if err != nil {
+		fatalf("%v", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 300 {
-		fatalf("toolbox: HTTP %d: %s", resp.StatusCode, respBody)
-	}
 	return respBody, resp.Header.Get("Content-Type")
 }
 

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -48,8 +48,11 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -85,6 +88,10 @@ func main() {
 		runDelete(os.Args[2:])
 	case "exec":
 		runExec(os.Args[2:])
+	case "upload":
+		runUpload(os.Args[2:])
+	case "download":
+		runDownload(os.Args[2:])
 	case "toolbox":
 		runToolbox(os.Args[2:])
 	case "start":
@@ -105,7 +112,7 @@ func main() {
 func printUsage() {
 	fmt.Fprintln(os.Stderr, "usage: user <subcommand> [flags]")
 	fmt.Fprintln(os.Stderr, "  chain:  balance | deposit | acknowledge")
-	fmt.Fprintln(os.Stderr, "  api:    providers | create | list | start | stop | delete | exec | toolbox | ssh-access | snapshots")
+	fmt.Fprintln(os.Stderr, "  api:    providers | create | list | start | stop | delete | exec | upload | download | toolbox | ssh-access | snapshots")
 }
 
 // ── Shared chain flags ───────────────────────────────────────────────────────
@@ -678,6 +685,116 @@ func runExec(args []string) {
 	}
 }
 
+// ── upload ───────────────────────────────────────────────────────────────────
+
+func runUpload(args []string) {
+	fs := flag.NewFlagSet("upload", flag.ExitOnError)
+	apiURL  := fs.String("api",  "http://localhost:8080", "Billing proxy URL")
+	keyHex  := fs.String("key",  "",                     "User private key (hex); or set USER_KEY env")
+	id      := fs.String("id",   "",                     "Sandbox ID (required)")
+	src     := fs.String("src",  "",                     "Local file path (required)")
+	dst     := fs.String("dst",  "",                     "Remote sandbox path (required)")
+	jsonOut := fs.Bool("json",   false,                  "Print machine-readable JSON")
+	_ = fs.Parse(args)
+
+	if *id == "" {
+		fatalf("--id is required")
+	}
+	if *src == "" {
+		fatalf("--src is required")
+	}
+	if *dst == "" {
+		fatalf("--dst is required")
+	}
+
+	data, err := os.ReadFile(*src)
+	if err != nil {
+		fatalf("read %s: %v", *src, err)
+	}
+
+	privKey := mustLoadKey(*keyHex)
+	var bodyBuf bytes.Buffer
+	writer := multipart.NewWriter(&bodyBuf)
+	part, err := writer.CreateFormFile("file", filepath.Base(*src))
+	if err != nil {
+		fatalf("create multipart file: %v", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		fatalf("write multipart file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		fatalf("close multipart writer: %v", err)
+	}
+
+	action := "files/upload?path=" + url.QueryEscape(*dst)
+	respBody, _ := signedToolboxRequest(privKey, *apiURL, *id, http.MethodPost, action, bodyBuf.Bytes(), writer.FormDataContentType())
+
+	if *jsonOut {
+		fmt.Println(prettyJSON(json.RawMessage(respBody)))
+		return
+	}
+	fmt.Printf("Uploaded %s to %s (%d bytes)\n", *src, *dst, len(data))
+}
+
+// ── download ─────────────────────────────────────────────────────────────────
+
+func runDownload(args []string) {
+	fs := flag.NewFlagSet("download", flag.ExitOnError)
+	apiURL    := fs.String("api",  "http://localhost:8080", "Billing proxy URL")
+	keyHex    := fs.String("key",  "",                     "User private key (hex); or set USER_KEY env")
+	id        := fs.String("id",   "",                     "Sandbox ID (required)")
+	src       := fs.String("src",  "",                     "Remote sandbox path (required)")
+	dst       := fs.String("dst",  "",                     "Local file path (required)")
+	overwrite := fs.Bool("overwrite", false,               "Overwrite local destination if it exists")
+	jsonOut   := fs.Bool("json", false,                    "Print machine-readable JSON metadata")
+	_ = fs.Parse(args)
+
+	if *id == "" {
+		fatalf("--id is required")
+	}
+	if *src == "" {
+		fatalf("--src is required")
+	}
+	if *dst == "" {
+		fatalf("--dst is required")
+	}
+	if _, err := os.Stat(*dst); err == nil && !*overwrite {
+		fatalf("%s already exists; pass --overwrite to replace it", *dst)
+	} else if err != nil && !os.IsNotExist(err) {
+		fatalf("stat %s: %v", *dst, err)
+	}
+
+	privKey := mustLoadKey(*keyHex)
+	action := "files/download?path=" + url.QueryEscape(*src)
+	respBody, contentType := signedToolboxRequest(privKey, *apiURL, *id, http.MethodGet, action, nil, "")
+	data := respBody
+	if strings.Contains(strings.ToLower(contentType), "application/json") {
+		var err error
+		data, err = downloadedFileContent(respBody)
+		if err != nil {
+			fatalf("parse download response: %v", err)
+		}
+	}
+	if dir := filepath.Dir(*dst); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fatalf("create destination directory: %v", err)
+		}
+	}
+	if err := os.WriteFile(*dst, data, 0644); err != nil {
+		fatalf("write %s: %v", *dst, err)
+	}
+
+	if *jsonOut {
+		fmt.Println(prettyJSON(map[string]any{
+			"src":   *src,
+			"dst":   *dst,
+			"bytes": len(data),
+		}))
+		return
+	}
+	fmt.Printf("Downloaded %s to %s (%d bytes)\n", *src, *dst, len(data))
+}
+
 // printSandboxOutput renders sandbox output in a bordered box with ANSI colors.
 func printSandboxOutput(id, command, output string, exitCode int) {
 	const (
@@ -980,6 +1097,70 @@ func getSandbox(privKey *ecdsa.PrivateKey, apiURL, id string) map[string]any {
 func stringField(m map[string]any, key string) (string, bool) {
 	v, ok := m[key].(string)
 	return v, ok && v != ""
+}
+
+func signedToolboxRequest(privKey *ecdsa.PrivateKey, apiURL, id, method, action string, body []byte, contentType string) ([]byte, string) {
+	msg, sig, walletAddr := signRequest(privKey, "toolbox", id, json.RawMessage(`{}`))
+
+	url := apiURL + "/api/toolbox/" + id + "/toolbox/" + strings.TrimPrefix(action, "/")
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Wallet-Address", walletAddr)
+	req.Header.Set("X-Signed-Message", msg)
+	req.Header.Set("X-Wallet-Signature", sig)
+	if body != nil {
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fatalf("toolbox: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		fatalf("toolbox: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+	return respBody, resp.Header.Get("Content-Type")
+}
+
+func downloadedFileContent(respBody []byte) ([]byte, error) {
+	var result struct {
+		Content  *string `json:"content"`
+		Data     *string `json:"data"`
+		Encoding string  `json:"encoding"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return respBody, nil
+	}
+
+	content := result.Content
+	if content == nil {
+		content = result.Data
+	}
+	if content == nil {
+		return respBody, nil
+	}
+	if result.Encoding == "" || strings.EqualFold(result.Encoding, "base64") {
+		decoded, err := base64.StdEncoding.DecodeString(*content)
+		if err == nil {
+			return decoded, nil
+		}
+		if strings.EqualFold(result.Encoding, "base64") {
+			return nil, err
+		}
+	}
+	return []byte(*content), nil
 }
 
 // signRequest builds the three auth headers required by the billing proxy.

--- a/cmd/user/main_test.go
+++ b/cmd/user/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -69,5 +70,34 @@ func TestWaitForSandboxStartedPollsUntilStarted(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("calls = %d; want 2", calls)
+	}
+}
+
+func TestDownloadedFileContent(t *testing.T) {
+	t.Parallel()
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("hello\n"))
+	got, err := downloadedFileContent([]byte(`{"content":"` + encoded + `"}`))
+	if err != nil {
+		t.Fatalf("downloadedFileContent base64: %v", err)
+	}
+	if string(got) != "hello\n" {
+		t.Fatalf("base64 content = %q; want hello newline", got)
+	}
+
+	got, err = downloadedFileContent([]byte(`{"content":"plain text","encoding":"utf-8"}`))
+	if err != nil {
+		t.Fatalf("downloadedFileContent text: %v", err)
+	}
+	if string(got) != "plain text" {
+		t.Fatalf("text content = %q; want plain text", got)
+	}
+
+	got, err = downloadedFileContent([]byte("raw bytes"))
+	if err != nil {
+		t.Fatalf("downloadedFileContent raw: %v", err)
+	}
+	if string(got) != "raw bytes" {
+		t.Fatalf("raw content = %q; want raw bytes", got)
 	}
 }


### PR DESCRIPTION
## Summary / What changed

- Add `cmd/user upload` for single-file uploads through the toolbox `files/upload` endpoint.
- Add `cmd/user download` for single-file downloads through the toolbox `files/download` endpoint.
- Stream upload data from disk instead of reading the whole local file into memory.
- Stream raw download responses to disk instead of buffering the whole file in memory.
- Keep file transfer explicit: upload requires `--src` and `--dst`, download requires `--src` and `--dst`.
- Protect local files by requiring `--overwrite` before download replaces an existing path.
- Return useful `{src,dst,bytes}` metadata from `upload --json` and `download --json`.
- Update the API reference so the rsync fallback points to the new CLI file transfer commands.
- Add tests for download response decoding fallback behavior.

## Why

In live sandbox testing, SSH command execution worked, but `scp` and rsync were not reliable enough to be the only documented sync path.

The toolbox already exposes file APIs. This PR gives users a supported CLI path instead of forcing brittle shell chunk uploads.

## Preserved guardrails

This does not change sealed sandbox behavior. File transfer still goes through the toolbox route, so existing owner checks and sealed sandbox blocks are preserved.

This PR does not change billing, sandbox lifecycle, or provider behavior.

## Tests

```bash
go test ./cmd/user ./internal/proxy ./internal/auth
git diff --check
```

I also checked the touched files for real keys, generated footers, and co-author trailers.

Live validation on 2026-04-23:

```text
create --wait --json
upload --src <tmp>/in.txt --dst /tmp/og-cli-json-smoke.txt --json
assert upload json has bytes=11
download --src /tmp/og-cli-json-smoke.txt --dst <tmp>/out.txt --overwrite --json
assert download json has bytes=11
cmp <tmp>/in.txt <tmp>/out.txt
delete
```

The live upload/download smoke passed against the public test provider.

## Real-world validation

This was tested against a live 0G Sandbox provider with snapshot `daytonaio/sandbox:0.5.0-slim`.

One implementation detail found during validation: Daytona `files/upload` expects `multipart/form-data` with the remote path in the `path` query parameter. A JSON body with `path` and `content` is rejected.

## Issue

Stacked on #39 because this builds on the automation-friendly CLI output helpers.
