### PR TITLE
fix(cli): parse deposit amounts exactly

### DIFF
--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -196,12 +196,16 @@ func runDeposit(args []string) {
 	fs := flag.NewFlagSet("deposit", flag.ExitOnError)
 	cf := addChainFlags(fs)
 	keyHex      := fs.String("key",      "", "User private key (hex); or set USER_KEY env")
-	amount      := fs.Float64("amount",  0.01, "Amount to deposit in 0G (e.g. 0.01)")
+	amount      := fs.String("amount",   "0.01", "Amount to deposit in 0G (e.g. 0.01)")
 	providerHex := fs.String("provider", "", "Provider address to deposit for (required)")
 	_ = fs.Parse(args)
 
 	if *providerHex == "" {
 		fatalf("--provider is required")
+	}
+	depositWei, err := parse0GAmountToNeuron(*amount)
+	if err != nil {
+		fatalf("--amount: %v", err)
 	}
 
 	privKey := mustLoadKey(*keyHex)
@@ -220,12 +224,11 @@ func runDeposit(args []string) {
 	}
 	auth.Context = ctx
 
-	depositWei := ogToNeuron(*amount)
 	auth.Value = depositWei
 
 	fmt.Printf("User:     %s\n", userAddr.Hex())
 	fmt.Printf("Provider: %s\n", providerAddr.Hex())
-	fmt.Printf("Amount:   %.6f 0G (%s neuron)\n", *amount, depositWei)
+	fmt.Printf("Amount:   %s 0G (%s neuron)\n", strings.TrimSpace(*amount), depositWei)
 	fmt.Printf("Contract: %s\n", cf.contract)
 
 	fmt.Println("\n[1/1] Deposit...")
@@ -947,12 +950,26 @@ func mustDialContract(ctx context.Context, rpcURL, contractHex string) (*ethclie
 	return eth, contract
 }
 
-func ogToNeuron(og float64) *big.Int {
-	ogBig := new(big.Float).SetFloat64(og)
-	neuronBig := new(big.Float).Mul(ogBig,
-		new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)))
-	n, _ := neuronBig.Int(nil)
-	return n
+func parse0GAmountToNeuron(amount string) (*big.Int, error) {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return nil, fmt.Errorf("must not be empty")
+	}
+
+	value, ok := new(big.Rat).SetString(amount)
+	if !ok {
+		return nil, fmt.Errorf("must be a decimal number")
+	}
+	if value.Sign() <= 0 {
+		return nil, fmt.Errorf("must be greater than zero")
+	}
+
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	scaled := new(big.Rat).Mul(value, new(big.Rat).SetInt(scale))
+	if scaled.Denom().Cmp(big.NewInt(1)) != 0 {
+		return nil, fmt.Errorf("has more than 18 decimal places")
+	}
+	return new(big.Int).Set(scaled.Num()), nil
 }
 
 func neuronTo0G(neuron *big.Int) float64 {

--- a/cmd/user/main_test.go
+++ b/cmd/user/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestParse0GAmountToNeuronIsExact(t *testing.T) {
+	tests := map[string]string{
+		"0.2":        "200000000000000000",
+		"0.01":       "10000000000000000",
+		"1":          "1000000000000000000",
+		"1.00000001": "1000000010000000000",
+	}
+
+	for input, want := range tests {
+		got, err := parse0GAmountToNeuron(input)
+		if err != nil {
+			t.Fatalf("parse0GAmountToNeuron(%q) returned error: %v", input, err)
+		}
+		if got.String() != want {
+			t.Fatalf("parse0GAmountToNeuron(%q) = %s, want %s", input, got, want)
+		}
+	}
+}
+
+func TestParse0GAmountToNeuronRejectsInvalidAmounts(t *testing.T) {
+	tests := []string{"", "abc", "-0.1", "0", "0.0000000000000000001"}
+
+	for _, input := range tests {
+		if got, err := parse0GAmountToNeuron(input); err == nil {
+			t.Fatalf("parse0GAmountToNeuron(%q) = %s, want error", input, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary / What changed

- Parse `cmd/user deposit --amount` as a decimal string instead of `float64`.
- Convert 0G to neuron with exact rational arithmetic.
- Reject zero, negative, invalid, and sub-neuron decimal amounts before loading a key or dialing RPC.
- Add focused tests for exact decimal conversion.

## Why

During a live 0G Sandbox smoke test, `--amount 0.2` printed and deposited `200000000000000011` neuron instead of exactly `200000000000000000` neuron.

This is a standard floating-point precision issue. Token amounts should not go through `float64` because users expect decimal CLI input to map exactly to the integer on-chain unit.

## Tests

```bash
go test ./cmd/user ./internal/proxy ./internal/auth
git diff --check
go run ./cmd/user/ deposit --provider 0xB831371eb2703305f1d9F8542163633D0675CEd7 --amount 0.0000000000000000001
```

The invalid sub-neuron command exits before key loading or RPC access with:

```text
error: --amount: has more than 18 decimal places
```

## Real-world validation

Observed on 2026-05-06 during a live testnet deposit against the public 0G Sandbox test provider. No private key or secret value is included in this PR.
