### PR TITLE
docs(skill): fix provider discovery

### DIFF
--- a/.claude/skills/0g-private-sandbox/SKILL.md
+++ b/.claude/skills/0g-private-sandbox/SKILL.md
@@ -128,14 +128,16 @@ Tell the user to save their private key securely — it will not be shown again.
 
 ### Step 1 — Discover providers
 
-**Direct path** — scan the chain:
+`providers` reads on-chain service registrations directly — there is **no `--api` flag**. It uses the `RPC_URL` and `SETTLEMENT_CONTRACT` you set during session setup (from the broker's `/api/info` on the broker path, or from your answers on the direct path), so the same command works for both paths:
+
 ```bash
 $USER_CLIproviders
 ```
 
-**Broker path** — query provider index via broker (no chain scan):
+To target a different network or contract without changing those env vars, pass the chain flags explicitly:
+
 ```bash
-$USER_CLIproviders --api $API
+$USER_CLIproviders --rpc "$RPC_URL" --contract "$SETTLEMENT_CONTRACT"
 ```
 
 After picking a provider, update `API` to the selected provider URL (from the export commands printed by the command). From this point on, `API` always points to the provider, not the broker.

--- a/skills/0g-private-sandbox/SKILL.md
+++ b/skills/0g-private-sandbox/SKILL.md
@@ -125,14 +125,17 @@ Tell the user to save their private key securely — it will not be shown again.
 
 ### Step 1 — Discover providers
 
-**Direct path** — scan the chain:
+`providers` reads on-chain service registrations directly — there is **no `--api` flag**. It uses the `RPC_URL` and `SETTLEMENT_CONTRACT` you set during session setup (from the broker's `/api/info` on the broker path, or from your answers on the direct path), so the same command works for both paths:
+
 ```bash
 go run ./cmd/user/ providers
 ```
 
-**Broker path** — query provider index via broker (no chain scan):
+To target a different network or contract without changing those env vars, pass the chain flags explicitly:
+
 ```bash
-go run ./cmd/user/ providers --api $API
+go run ./cmd/user/ providers \
+  --rpc "$RPC_URL" --contract "$SETTLEMENT_CONTRACT"
 ```
 
 After picking a provider, update `API` to the selected provider URL (from the export commands printed by the command). From this point on, `API` always points to the provider, not the broker.


### PR DESCRIPTION
## Summary / What changed

- Fix the provider-discovery step in the user skill so it matches the shipped `cmd/user` CLI. The `providers` subcommand has **no `--api` flag** — it reads on-chain service registrations directly via `--rpc`/`--contract`/`--chain-id` (the `--rpc`/`--contract` defaults fall back to the `RPC_URL`/`SETTLEMENT_CONTRACT` env vars). The skill previously documented `providers --api $API`, which exits with `flag provided but not defined: -api`.
- Drop the misleading "Direct path / Broker path (no chain scan)" split in favor of one accurate command. `providers` always scans the chain; whether the user arrived via the broker path or the direct path, by this step they already have `RPC_URL`/`SETTLEMENT_CONTRACT` exported — the broker path sets them from `GET /api/info`, the direct path from the user's answers — so the same command serves both.
- Document the optional `--rpc`/`--contract` overrides, aligning the skill with `docs/API_REFERENCE.md`, which already states `providers` takes "no `--api` flag".
- The repo ships two tracked copies of this skill (`skills/0g-private-sandbox/SKILL.md` and `.claude/skills/0g-private-sandbox/SKILL.md`); both carried the identical drift and are fixed the same way, preserving each file's CLI-invocation convention.

## Why

A new user following the public skill hits a hard failure at the very first step — the documented broker-discovery command doesn't even parse. The fix points users at the path the shipped code actually supports: read the chain config (`contract_address`/`chain_id`/`rpc_url`) from the broker's `GET /api/info` (which the skill's setup step already does) and feed it to the direct on-chain scan.

## Tests

Docs-only change. Verified against the shipped code on the current `main`:

```
$ go run ./cmd/user/ providers --api x
flag provided but not defined: -api
Usage of providers:
  -chain-id int      Chain ID
  -contract string   Settlement contract address
  -rpc string        RPC endpoint
  -tapp string       TappRegistry contract address (required for ack)
exit status 2
```

`cmd/user/main.go`'s `runProviders` registers only the shared chain flags (`--rpc`/`--chain-id`/`--contract`/`--tapp`) through `addChainFlags`; there is no `--api`. Those `--rpc`/`--contract` defaults read the `RPC_URL`/`SETTLEMENT_CONTRACT` env vars, so the broker-supplied config flows through without an extra flag.

Checked the diff for secrets — placeholders only, no addresses/keys/endpoints.

## Maintainer question

Two related discovery gaps I left untouched here, flagged for your call:

1. **Hosted broker URL.** The broker path assumes the user already knows a broker URL, but no hosted broker URL is documented anywhere in the repo, so a fresh user can't reach `GET /api/info` to begin with. Should the public testnet broker URL be documented (README or skill) — or is that intentionally left to operators?
2. **Default `--contract` drift.** `addChainFlags` hardcodes a default settlement contract. If live providers register on a different contract, `providers` against the default prints "No providers found on-chain." Would you prefer keeping the default in sync, or dropping it so `SETTLEMENT_CONTRACT` (from the broker's `/api/info`) is always the source of truth? Happy to take this in a separate PR.
