### PR TITLE
fix: remove hardcoded dev contract default, require SETTLEMENT_CONTRACT

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -56,7 +56,6 @@ import (
 const (
 	defaultRPC      = "https://evmrpc-testnet.0g.ai"
 	defaultChainID  = int64(16602)
-	defaultContract = "0x2024eB0Cc14316fF8Cc425bFB7CC37FD8713E9b3"
 )
 
 func main() {
@@ -106,7 +105,7 @@ func runRegister(args []string) {
 	fs := flag.NewFlagSet("register", flag.ExitOnError)
 	rpc            := fs.String("rpc",           defaultRPC,              "RPC endpoint")
 	chainID        := fs.Int64("chain-id",        defaultChainID,          "Chain ID")
-	contractHex    := fs.String("contract",       defaultContract,         "Settlement contract address")
+	contractHex    := fs.String("contract",       envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
 	keyHex         := fs.String("key",            "",                      "Provider private key (hex); or set PROVIDER_KEY env")
 	appId          := fs.String("app-id",         "",                      "TappRegistry appId to bind (required; must already be registered in tapp)")
 	serviceURL     := fs.String("url",            "",                      "Provider service URL (required)")
@@ -165,7 +164,7 @@ func runDeregister(args []string) {
 	fs := flag.NewFlagSet("deregister", flag.ExitOnError)
 	rpc         := fs.String("rpc",      defaultRPC,      "RPC endpoint")
 	chainID     := fs.Int64("chain-id",  defaultChainID,  "Chain ID")
-	contractHex := fs.String("contract", defaultContract, "Settlement contract address")
+	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
 	keyHex      := fs.String("key",      "",              "Provider private key (hex); or set PROVIDER_KEY env")
 	_ = fs.Parse(args)
 
@@ -204,7 +203,7 @@ func runDeregister(args []string) {
 func runStatus(args []string) {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 	rpc         := fs.String("rpc",      defaultRPC,      "RPC endpoint")
-	contractHex := fs.String("contract", defaultContract, "Settlement contract address")
+	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
 	keyHex      := fs.String("key",      "",              "Provider private key; or set PROVIDER_KEY env")
 	addrHex     := fs.String("address",  "",              "Provider address (alternative to --key)")
 	_ = fs.Parse(args)
@@ -264,7 +263,7 @@ func runWithdraw(args []string) {
 	fs := flag.NewFlagSet("withdraw", flag.ExitOnError)
 	rpc         := fs.String("rpc",      defaultRPC,      "RPC endpoint")
 	chainID     := fs.Int64("chain-id",  defaultChainID,  "Chain ID")
-	contractHex := fs.String("contract", defaultContract, "Settlement contract address")
+	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
 	keyHex      := fs.String("key",      "",              "Provider private key; or set PROVIDER_KEY env")
 	_ = fs.Parse(args)
 
@@ -668,6 +667,13 @@ func signRequest(privKey *ecdsa.PrivateKey, action, resourceID string, payload j
 	return base64.StdEncoding.EncodeToString(msgBytes), "0x" + hex.EncodeToString(sigBytes), addr.Hex()
 }
 
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
 func resolveEnv(flagVal, envVar, label string) string {
 	if flagVal != "" {
 		return flagVal
@@ -703,6 +709,9 @@ func parseBigInt(s, name string) *big.Int {
 }
 
 func dialContract(ctx context.Context, rpcURL, contractHex string) (*ethclient.Client, *chain.SandboxServing) {
+	if contractHex == "" {
+		fatalf("settlement contract is required: set --contract or SETTLEMENT_CONTRACT env var (e.g. from broker GET /api/info)")
+	}
 	eth, err := ethclient.Dial(rpcURL)
 	if err != nil {
 		fatalf("dial rpc: %v", err)

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -130,7 +130,7 @@ func addChainFlags(fs *flag.FlagSet) *chainFlags {
 	cf := &chainFlags{}
 	fs.StringVar(&cf.rpc,      "rpc",      envOrDefault("RPC_URL", "https://evmrpc-testnet.0g.ai"),                       "RPC endpoint")
 	fs.Int64Var(&cf.chainID,   "chain-id", 16602,                                                                          "Chain ID")
-	fs.StringVar(&cf.contract, "contract", envOrDefault("SETTLEMENT_CONTRACT", "0x2024eB0Cc14316fF8Cc425bFB7CC37FD8713E9b3"), "Settlement contract address")
+	fs.StringVar(&cf.contract, "contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: set --contract or SETTLEMENT_CONTRACT env)")
 	fs.StringVar(&cf.tapp,     "tapp",     envOrDefault("TAPP_REGISTRY", ""),                                              "TappRegistry contract address (required for ack)")
 	return cf
 }
@@ -1037,6 +1037,9 @@ func mustLoadKey(keyHex string) *ecdsa.PrivateKey {
 
 // mustDialContract dials the RPC and binds the SandboxServing contract.
 func mustDialContract(ctx context.Context, rpcURL, contractHex string) (*ethclient.Client, *chain.SandboxServing) {
+	if contractHex == "" {
+		fatalf("settlement contract is required: set --contract or SETTLEMENT_CONTRACT env var (e.g. from broker GET /api/info)")
+	}
 	eth, err := ethclient.Dial(rpcURL)
 	if err != nil {
 		fatalf("dial rpc: %v", err)


### PR DESCRIPTION
## Problem

The CLI hardcoded a dev environment contract address (`0x2024eB0Cc14316fF8Cc425bFB7CC37FD8713E9b3`) as the default for `--contract`. When `SETTLEMENT_CONTRACT` env var was not set (e.g. env var lost across separate shell invocations, or the `providers --api` error caused fallback), the CLI silently queried the dev contract and returned dev providers instead of production ones.

This was the root cause of the skill hitting wrong provider URLs: the `--api` flag error (fixed in PR #42) caused fallback to the default contract, which pointed at dev infrastructure.

## What `--api` was for

`--api` tells the CLI where the provider HTTP API is (e.g. `create`, `list`, `exec` commands). But `providers` is a chain-scan command — it never had `--api`. The SKILL.md incorrectly documented `providers --api $API`, which was introduced in commit `6c0e926` (Co-Authored-By: Claude Sonnet 4.6) during the v2 skill refactor. It was an AI hallucination, not an intentional feature.

## Fix

- **`cmd/user/main.go`**: `addChainFlags` `--contract` default changed from dev contract address to empty string; `mustDialContract` adds explicit empty-check with clear error message
- **`cmd/provider/main.go`**: removed `defaultContract` constant; 4 `--contract` flags changed to `envOrDefault("SETTLEMENT_CONTRACT", "")`; added `envOrDefault` helper (matching user CLI); `dialContract` adds empty-check

## Behavior change

Before:
```bash
$ go run ./cmd/user/ providers
# silently queries dev contract 0x2024eB0Cc..., returns dev providers
```

After:
```bash
$ go run ./cmd/user/ providers
settlement contract is required: set --contract or SETTLEMENT_CONTRACT env var (e.g. from broker GET /api/info)

$ SETTLEMENT_CONTRACT=0x... go run ./cmd/user/ providers
# queries the correct contract
```

## Relationship to PR #42

PR #42 fixes the SKILL.md documentation (removes non-existent `--api` flag). This PR fixes the CLI code root cause — there should be no default contract address. The two PRs are complementary.

## When `--api` was introduced

`providers --api $API` was added in commit `6c0e926` (2026-03-19, "redesign: dark developer UI with provider market, skill guide, and v2 animations"), co-authored by Claude Sonnet 4.6. It was an AI-generated hallucination during a large SKILL.md refactor — the `providers` subcommand never supported `--api`.