### PR TITLE
fix(runner): enforce cross-sandbox network isolation via firewall sidecar

### DIFF
--- a/docker/sandbox/docker-compose.yml
+++ b/docker/sandbox/docker-compose.yml
@@ -205,6 +205,12 @@ services:
       # Image default is true (baked into Dockerfile); must explicitly set
       # to false to enable Docker CFS/memory cgroup limits on sandbox containers.
       - RESOURCE_LIMITS_DISABLED=false
+      # NOTE: `INTER_SANDBOX_NETWORK_ENABLED=false` is the upstream-supported
+      # way to disable cross-sandbox traffic — but it landed in daytona-runner
+      # only ~v0.179+ (May 2026). Our pinned image (sha256:a1de89138d...,
+      # Feb 2026) predates it; setting it here is a no-op on that image.
+      # Until we upgrade the runner image, cross-sandbox isolation is
+      # enforced by the `runner-firewall` sidecar service below.
       - AWS_ENDPOINT_URL=http://minio:9000
       - AWS_REGION=us-east-1
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
@@ -219,6 +225,46 @@ services:
     depends_on:
       - minio
     privileged: true
+    restart: always
+
+  # SECURITY: cross-sandbox network isolation enforcer.
+  # Shares the runner container's network namespace and inserts an
+  # iptables rule in the DOCKER-USER chain that drops any packet
+  # forwarded between two containers on docker0 (the runner's internal
+  # bridge where all sandboxes live). Reconciles every 60s so the rule
+  # is restored after runner / dockerd restarts.
+  #
+  # docker0 -> docker0 forwarding is exactly cross-sandbox traffic.
+  # sandbox -> external (egress via eth0) and sandbox -> gateway (INPUT
+  # to the runner, not FORWARD) are unaffected.
+  #
+  # daytona-runner's own iptables persistence loop manages a separate
+  # set of chains (per-sandbox egress rules); it does not touch
+  # DOCKER-USER, so this sidecar and daytona-runner coexist cleanly.
+  #
+  # Once we upgrade the runner image to v0.179+ this sidecar can be
+  # replaced by setting `INTER_SANDBOX_NETWORK_ENABLED=false` on the
+  # runner service.
+  runner-firewall:
+    image: alpine:3.22
+    network_mode: "service:runner"
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      runner:
+        condition: service_started
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache iptables >/dev/null 2>&1
+        echo "runner-firewall: enforcing cross-sandbox network isolation on DOCKER-USER"
+        while true; do
+          iptables -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+            || ( iptables -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP \
+                 && echo "$(date -u +%FT%TZ) inserted DOCKER-USER docker0->docker0 DROP rule" )
+          sleep 60
+        done
     restart: always
 
   proxy:


### PR DESCRIPTION
## Summary

Add a `runner-firewall` sidecar to `docker/sandbox/docker-compose.yml`. It shares the runner container's network namespace (`network_mode: "service:runner"`) and installs an `iptables DROP` rule in the `DOCKER-USER` chain for `docker0 → docker0` forwarding — exactly cross-sandbox traffic. Egress and gateway traffic are unaffected.

## Why

Verified empirically on a 0g-sandbox provider host: real `cmd/user create` sandboxes (full EIP-191 → billing-proxy → daytona path) share the runner's internal `docker0` bridge with `enable_icc=true`. Two sibling sandboxes can freely ping / HTTP each other.

The upstream-supported fix (`INTER_SANDBOX_NETWORK_ENABLED=false` on the runner) only landed in daytona-runner ~v0.179 (May 2026). Our pinned image (`sha256:a1de89138d…`, Feb 2026) predates it — confirmed empirically by setting the env and observing fresh sandboxes still landing on `docker0`. A clean upgrade requires daytona-runner v0.179+ alongside the v0.189 daytona-api adapter work, which is a separate effort.

## How

```yaml
runner-firewall:
  image: alpine:3.22
  network_mode: "service:runner"     # share runner's netns
  cap_add: [NET_ADMIN]
  depends_on:
    runner:
      condition: service_started
  command:
    - sh
    - -c
    - |
      apk add --no-cache iptables >/dev/null 2>&1
      while true; do
        iptables -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
          || iptables -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
        sleep 60
      done
  restart: always
```

- Shares runner's network namespace → iptables ops modify the same tables runner sees.
- `DOCKER-USER` is Docker's documented hook for persistent user rules; daytona-runner's own iptables persistence loop manages separate chains (per-sandbox egress), so the sidecar and runner coexist.
- 60s reconcile restores the rule after manual flush / dockerd restart / runner restart.
- Sidecar holds only `NET_ADMIN` — no docker socket, not `privileged: true`.

## Verified

A/B against the unpatched public testnet provider (`provider-private-sandbox-testnet.0g.ai`) on the same exploit primitive:

```
LOCAL (with this PR):
  SB_A → SB_B:8080 HTTP   →  exit=124 timeout, no banner
  SB_A → SB_B     ICMP    →  100% packet loss
  SB_A → 8.8.8.8  ICMP    →  0% loss (egress intact)
  iptables -F DOCKER-USER →  sidecar re-inserts within 60s

TESTNET (no patch):
  SB-A → SB-B:8080 HTTP   →  Connection succeeded! HTTP/1.0 200 OK
                            TESTNET-LEAK   ← banner crosses sandbox boundary
```

## Scope

This PR addresses **M1 cross-sandbox network isolation only**. The orthogonal M2 issue (in-sandbox `root` is host-kernel-equivalent without user-namespace remapping) is **not** in this PR — it requires Sysbox or equivalent runtime support which we explored and confirmed mechanically works on our stack (uid_map remap, M2 verified), but full production rollout depends on:

- tapp enclave OS shipping Sysbox + ext4-backed `/var/lib/docker` + kernel ≥ 5.12 or shiftfs ([0gfoundation/0g-tapp#21](https://github.com/0gfoundation/0g-tapp/issues/21))
- daytona-runner image upgrade to v0.179+ (newer IP-lookup behaviour for user-defined networks)
- billing proxy adapter for v0.189 daytona-api (Org-based API surface, cursor pagination, DB schema)

M2 has been spiked end-to-end on this host and validated mechanically; the spike learnings (Sysbox kernel constraints, `--alias-dns=false` workaround, `sandbox-net` design, daytona-runner IP lookup limitation) will inform the follow-up PR.

## Test plan

- [x] Compose deploys cleanly via `tapp-cli start-app`
- [x] `runner-firewall` sidecar starts, installs rule (visible in `iptables -L DOCKER-USER`)
- [x] Real EIP-191 `cmd/user create` → cross-sandbox HTTP/ICMP blocked
- [x] Egress (sandbox → 8.8.8.8) still works
- [x] Manual `iptables -F DOCKER-USER` → reconcile within 60s
- [ ] Production redeploy on the public testnet provider + re-run mesh probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
