### PR TITLE
docs: document hosted testnet broker, drop stale settlement contract

### DIFF
--- a/.claude/skills/0g-private-sandbox/SKILL.md
+++ b/.claude/skills/0g-private-sandbox/SKILL.md
@@ -45,7 +45,7 @@ echo "CLI ready: $USER_CLI"
 
 A broker aggregates provider discovery and exposes chain config — you don't need to know the network details manually.
 
-- `yes` — provide the broker URL (e.g. `https://broker.example.com`)
+- `yes` — provide the broker URL (hosted testnet broker: `https://private-sandbox-testnet.0g.ai`)
 - `no` — I'll configure network and contract manually
 
 **If yes → broker path:**

--- a/README.md
+++ b/README.md
@@ -92,14 +92,15 @@ Then just describe what you want in plain language, for example:
 
 ---
 
-Claude will walk you through the rest. When asked for configuration details, the key piece
-of information you need is:
+Claude will walk you through the rest. When asked for configuration details, the only piece
+of information you need is the hosted testnet broker:
 
 | Item | Value |
 |------|-------|
-| **Testnet contract** | `0xd7e0CD227e602FedBb93c36B1F5bf415398508a4` |
-| **RPC** | `https://evmrpc-testnet.0g.ai` |
-| **Chain ID** | `16602` |
+| **Testnet broker** | `https://private-sandbox-testnet.0g.ai` |
+
+Claude (or the CLI) reads the rest — `contract_address`, `rpc_url` (`https://evmrpc-testnet.0g.ai`),
+and `chain_id` (`16602`) — from the broker's `GET /api/info`, so there's nothing else to copy by hand.
 
 Claude will handle onboarding, wallet setup, deposit, sandbox creation, and OpenClaw
 configuration automatically.

--- a/README.zh.md
+++ b/README.zh.md
@@ -85,13 +85,13 @@ claude
 
 ---
 
-Claude 会引导你完成后续所有步骤。需要填写配置时，关键信息如下：
+Claude 会引导你完成后续所有步骤。需要填写配置时，你唯一需要提供的就是托管的测试网 Broker：
 
 | 项目 | 值 |
 |------|-----|
-| **测试网合约** | `0xd7e0CD227e602FedBb93c36B1F5bf415398508a4` |
-| **RPC** | `https://evmrpc-testnet.0g.ai` |
-| **Chain ID** | `16602` |
+| **测试网 Broker** | `https://private-sandbox-testnet.0g.ai` |
+
+Claude（或 CLI）会从 Broker 的 `GET /api/info` 读取其余信息：`contract_address`、`rpc_url`（`https://evmrpc-testnet.0g.ai`）和 `chain_id`（`16602`），因此无需手动填写其他内容。
 
 ---
 

--- a/skills/0g-private-sandbox/SKILL.md
+++ b/skills/0g-private-sandbox/SKILL.md
@@ -40,7 +40,7 @@ export PATH=$PATH:/usr/local/go/bin
 
 A broker aggregates provider discovery and exposes chain config — you don't need to know the network details manually.
 
-- `yes` — provide the broker URL (e.g. `https://broker.example.com`)
+- `yes` — provide the broker URL (hosted testnet broker: `https://private-sandbox-testnet.0g.ai`)
 - `no` — I'll configure network and contract manually
 
 **If yes → broker path:**


### PR DESCRIPTION
## Summary / What changed

- The README Quickstart (and the Chinese `README.zh.md`) hardcoded a testnet settlement contract that no live provider is registered on. Following it, `go run ./cmd/user/ providers` returns "No providers found on-chain" and onboarding fails at step one. Replaced that row with the hosted testnet broker `https://private-sandbox-testnet.0g.ai`, and added a note that `contract_address`, `rpc_url`, and `chain_id` are read from the broker's `GET /api/info`.
- Both tracked copies of the user skill (`skills/0g-private-sandbox/SKILL.md` and `.claude/skills/0g-private-sandbox/SKILL.md`) used a `https://broker.example.com` placeholder in the "Do you have a Broker URL?" step. Pointed them at the hosted testnet broker so a new user has a concrete default.
- No settlement contract address is hardcoded anywhere now — the broker's `/api/info` is the single source of truth. This is the docs-side follow-up to #43 (made `SETTLEMENT_CONTRACT` required, removed the dev-contract default) and #42 (fixed the skill's `providers` command).

## Why

A new user cloning the repo and following the public README today is pointed at a settlement contract that returns zero providers, so discovery is empty before they even pick a provider. The live contract is only discoverable through a broker's `GET /api/info`, but no hosted broker URL was documented anywhere in the repo. This change unblocks first-run onboarding.

## Tests

Docs-only change. Verified against the live testnet:

- `providers` against the old README contract (`0xd7e0…`) → `No providers found on-chain.`
- `providers` using the contract from the broker's `GET /api/info` → returns the live providers.
- Confirmed the stale contract no longer appears in `README.md` / `README.zh.md`, and no settlement contract is hardcoded in the diff.

## Real-world validation

Ran the full skill flow against the hosted testnet broker end to end: discover providers → create sandbox → `exec` a command → delete. All steps succeeded.

## Related

- Follows #42 (skill `providers --api` fix) and #43 (remove hardcoded dev contract default, require `SETTLEMENT_CONTRACT`).
