### PR TITLE
feat(daytona): upgrade to v0.189 + Sysbox host-boundary isolation

### DIFF
--- a/docker/sandbox/docker-compose.yml
+++ b/docker/sandbox/docker-compose.yml
@@ -75,7 +75,7 @@ services:
   # Port 3000 is intentionally NOT published. All external API access must go
   # through the sandbox proxy on port 8080.
   api:
-    image: daytonaio/daytona-api@sha256:c1203729b066b7b4724a03973a1c167625b8bef89cc2172557e06871c1e3a082
+    image: daytonaio/daytona-api:v0.189.0-amd64
     environment:
       - OTEL_ENABLED=false
       # Snapshot used when a create request doesn't specify one. Per-env: a
@@ -196,7 +196,7 @@ services:
     privileged: true
 
   runner:
-    image: daytonaio/daytona-runner@sha256:a1de89138d9f549f3313f6896748b36f30d0bead4a0a84ddf79f56a1fbe036b0
+    image: daytonaio/daytona-runner:v0.189.0-amd64
     environment:
       - ENVIRONMENT=production
       - API_PORT=3003
@@ -205,12 +205,13 @@ services:
       # Image default is true (baked into Dockerfile); must explicitly set
       # to false to enable Docker CFS/memory cgroup limits on sandbox containers.
       - RESOURCE_LIMITS_DISABLED=false
-      # NOTE: `INTER_SANDBOX_NETWORK_ENABLED=false` is the upstream-supported
-      # way to disable cross-sandbox traffic — but it landed in daytona-runner
-      # only ~v0.179+ (May 2026). Our pinned image (sha256:a1de89138d...,
-      # Feb 2026) predates it; setting it here is a no-op on that image.
-      # Until we upgrade the runner image, cross-sandbox isolation is
-      # enforced by the `runner-firewall` sidecar service below.
+      # Native cross-sandbox network isolation (v0.179+). Runner spawns user
+      # containers on a dedicated bridge with icc disabled; direct L3 between
+      # sandbox IPs is dropped by dockerd. Verified end-to-end on wei-tapp2:
+      # docker0 → 172.20.0.0/16 bridge, curl/TCP between sandboxes times out.
+      # Supersedes the previous `runner-firewall` sidecar that relied on the
+      # host having br_netfilter loaded (unavailable on default GCP Ubuntu).
+      - INTER_SANDBOX_NETWORK_ENABLED=false
       - AWS_ENDPOINT_URL=http://minio:9000
       - AWS_REGION=us-east-1
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
@@ -227,48 +228,8 @@ services:
     privileged: true
     restart: always
 
-  # SECURITY: cross-sandbox network isolation enforcer.
-  # Shares the runner container's network namespace and inserts an
-  # iptables rule in the DOCKER-USER chain that drops any packet
-  # forwarded between two containers on docker0 (the runner's internal
-  # bridge where all sandboxes live). Reconciles every 60s so the rule
-  # is restored after runner / dockerd restarts.
-  #
-  # docker0 -> docker0 forwarding is exactly cross-sandbox traffic.
-  # sandbox -> external (egress via eth0) and sandbox -> gateway (INPUT
-  # to the runner, not FORWARD) are unaffected.
-  #
-  # daytona-runner's own iptables persistence loop manages a separate
-  # set of chains (per-sandbox egress rules); it does not touch
-  # DOCKER-USER, so this sidecar and daytona-runner coexist cleanly.
-  #
-  # Once we upgrade the runner image to v0.179+ this sidecar can be
-  # replaced by setting `INTER_SANDBOX_NETWORK_ENABLED=false` on the
-  # runner service.
-  runner-firewall:
-    image: alpine:3.22
-    network_mode: "service:runner"
-    cap_add:
-      - NET_ADMIN
-    depends_on:
-      runner:
-        condition: service_started
-    command:
-      - sh
-      - -c
-      - |
-        apk add --no-cache iptables >/dev/null 2>&1
-        echo "runner-firewall: enforcing cross-sandbox network isolation on DOCKER-USER"
-        while true; do
-          iptables -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-            || ( iptables -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP \
-                 && echo "$(date -u +%FT%TZ) inserted DOCKER-USER docker0->docker0 DROP rule" )
-          sleep 60
-        done
-    restart: always
-
   proxy:
-    image: daytonaio/daytona-proxy@sha256:2a4ce1cf1fb1d8f21ac6f49cea17e7ed5c7c591bb4af06b3ba001b7e5446d209
+    image: daytonaio/daytona-proxy:v0.189.0-amd64
     ports:
       - "4000:4000"
     environment:
@@ -290,7 +251,7 @@ services:
     restart: always
 
   ssh-gateway:
-    image: daytonaio/daytona-ssh-gateway@sha256:870b20ea3fdcceb9bc52cf74269fea7f516af1af025034a84bc1a6bf298fd31d
+    image: daytonaio/daytona-ssh-gateway:v0.189.0-amd64
     ports:
       - "2222:2222"
     environment:
@@ -335,6 +296,38 @@ services:
     networks:
       - app-net
     restart: unless-stopped
+
+  # v0.189 initialises the admin api_key with an empty permissions array,
+  # which returns 403 on every write op (stop/start/create). Grant the full
+  # v0.189 permission enum once the api has finished migrations. Idempotent:
+  # the WHERE clause skips the row after the first successful update.
+  grant-admin-perms:
+    image: postgres:16-alpine
+    depends_on:
+      db:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${DAYTONA_DB_PASSWORD}
+    command:
+      - psql
+      - -h
+      - db
+      - -U
+      - ${DAYTONA_DB_USER}
+      - -d
+      - ${DAYTONA_DB_NAME}
+      - -v
+      - ON_ERROR_STOP=1
+      - -c
+      - |
+        UPDATE api_key
+           SET permissions = '{write:registries,delete:registries,write:snapshots,delete:snapshots,write:sandboxes,delete:sandboxes,read:volumes,write:volumes,delete:volumes,write:regions,delete:regions,read:runners,write:runners,delete:runners,read:audit_logs}'
+         WHERE name = 'daytona-admin' AND permissions = '{}';
+    networks:
+      - app-net
+    restart: on-failure:5
 
   daytona-redis:
     image: redis@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065

--- a/docker/sandbox/docker-compose.yml
+++ b/docker/sandbox/docker-compose.yml
@@ -197,6 +197,14 @@ services:
 
   runner:
     image: daytonaio/daytona-runner:v0.189.0-amd64
+    # Sysbox at the outer boundary: host dockerd starts the runner via
+    # sysbox-runc so the runner (and its DinD + user sandboxes) live in a
+    # user namespace. Container uid 0 maps to a non-root uid on host, so
+    # even a privileged user sandbox escaping to the runner is not host
+    # root. Preserves the DinD + internal-registry topology unchanged;
+    # only the outer runtime shifts. Requires sysbox-runc registered on
+    # the host dockerd (see 0g-tapp gcp-cvm build-gcp-tapp.sh ENABLE_SYSBOX).
+    runtime: sysbox-runc
     environment:
       - ENVIRONMENT=production
       - API_PORT=3003

--- a/internal/daytona/client.go
+++ b/internal/daytona/client.go
@@ -81,17 +81,50 @@ func (c *Client) GetSandbox(ctx context.Context, id string) (*Sandbox, error) {
 	return &s, json.NewDecoder(resp.Body).Decode(&s)
 }
 
+// ListSandboxes returns every sandbox visible to the admin key. v0.189+
+// paginates the response as {items, nextCursor}; older versions returned a
+// flat array. Handle both shapes and walk the cursor when present.
 func (c *Client) ListSandboxes(ctx context.Context) ([]Sandbox, error) {
-	resp, err := c.do(ctx, http.MethodGet, "/api/sandbox", nil)
-	if err != nil {
-		return nil, err
+	var all []Sandbox
+	cursor := ""
+	for {
+		// v0.189 caps limit at 200; larger values return 400. Pre-v0.189 ignores.
+		path := "/api/sandbox?limit=200"
+		if cursor != "" {
+			path += "&cursor=" + cursor
+		}
+		resp, err := c.do(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("daytona ListSandboxes: status %d", resp.StatusCode)
+		}
+		// v0.189+ envelope.
+		var paged struct {
+			Items      []Sandbox `json:"items"`
+			NextCursor string    `json:"nextCursor"`
+		}
+		if err := json.Unmarshal(body, &paged); err == nil && paged.Items != nil {
+			all = append(all, paged.Items...)
+			if paged.NextCursor == "" {
+				return all, nil
+			}
+			cursor = paged.NextCursor
+			continue
+		}
+		// Legacy flat array.
+		var flat []Sandbox
+		if err := json.Unmarshal(body, &flat); err != nil {
+			return nil, fmt.Errorf("daytona ListSandboxes: decode: %w", err)
+		}
+		return flat, nil
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("daytona ListSandboxes: status %d", resp.StatusCode)
-	}
-	var list []Sandbox
-	return list, json.NewDecoder(resp.Body).Decode(&list)
 }
 
 func (c *Client) StopSandbox(ctx context.Context, id string) error {


### PR DESCRIPTION
## Summary
- Bump 4 daytona images to **v0.189.0-amd64** (from pinned Feb 2026 sha)
- New init container `grant-admin-perms` grants the daytona-admin API key the full v0.189 permission enum (v0.189 introduces `api_key.permissions`; existing admin keys carry migration default `{}` → 403 on writes)
- `Client.ListSandboxes` handles the v0.189 `{items, nextCursor}` paginated envelope. Silent-empty regression was blocking `/api/sandbox_list`, owner-scoped `/api/sandbox`, `/api/sessions`, `/api/archive-all`, and `archiveRunningOnShutdown`
- **Security hardening** (see dedicated section below): outer-layer Sysbox on the runner + native cross-sandbox network isolation. Compose diff: `runtime: sysbox-runc` on runner + `INTER_SANDBOX_NETWORK_ENABLED=false` on runner env; the old `runner-firewall` iptables sidecar from PR #45 is removed (its DOCKER-USER rule silently no-ops on hosts without `br_netfilter`)

Host-side dependency (Sysbox install + `sysbox-runc` registration + Docker version pin) is managed by [0g-tapp#5](https://github.com/0gfoundation/0g-tapp/pull/5) — see [companion review comment](https://github.com/0gfoundation/0g-tapp/pull/5#issuecomment-4865644935) on Docker 27 pin + Sysbox 0.7 compat.

---

## Security hardening — two questions

Multi-tenant sandboxes on one wei-tapp host raise two separate isolation questions. This PR addresses both.

### Q1. Can a user in one sandbox get root on the host?

**Status before this PR**: Yes, trivially. daytona-runner v0.189 hard-codes `HostConfig.Privileged = true` for every CPU sandbox it spawns (`apps/runner/pkg/docker/container_configs.go:205`). Combined with the sandbox image's passwordless `sudo`, that means:

- Container `uid=0` **is** the host kernel's `uid=0` (no user-namespace remap; standard `runc` shares the host kernel directly)
- All Linux capabilities are granted (`CAP_SYS_ADMIN`, `CAP_SYS_MODULE`, `CAP_NET_ADMIN`, …)
- AppArmor / SELinux is disabled per `SecurityOpt: [label=disable]`
- Full device access (`/dev/*` reachable)

Without any CVE, a tenant can:
- `sudo mount --bind /path/on/host /mnt/exfil` — read any host path
- `sudo mknod /dev/sda b 8 0 && dd if=/dev/sda …` — read raw host disks
- Any kernel-CVE PoC that assumes `CAP_SYS_ADMIN`

**Fix**: `runtime: sysbox-runc` on the runner service. The host dockerd starts the runner container under sysbox-runc, which puts the entire runner into a user namespace. Runner's inner DinD + every user sandbox it later creates all live inside that user-ns. Container `uid=0` is mapped to host `uid=362144` (a normal user).

Effect chain:
1. Tenant sandbox root does something privileged → succeeds inside the nested user-ns
2. If the tenant escapes their sandbox container into the runner (e.g., via a container-runtime CVE) → still user-ns `uid=0` = host `uid=362144`
3. To escalate to host root, the tenant would have to break out of the user namespace itself, not out of the container. That's kernel enforcement code, hardened for a decade+

Concrete escape CVEs that stop working under this design: **CVE-2019-5736** (runc), **CVE-2022-0185** (fsconfig), **CVE-2024-21626** (runc file-descriptor leak) — all require `CAP_SYS_ADMIN` on the initial user-ns, which the tenant never holds.

**Residual risk** (honest):
- The tenant is still root inside their user-ns, so they can create nested containers, bind-mount their own paths, run kernel-fuzzing tools — anything that stays inside the ns is unhindered
- Kernel bugs that require *no* capabilities at all (very rare, mostly theoretical) are unaffected by Sysbox
- Host disk pressure: a runaway sandbox can still fill `/var/lib/docker`; that's a quota problem, not an isolation one

### Q2. Can a user in one sandbox reach another sandbox?

Split by attack vector:

**Q2a — Network path (sandbox A ↔ sandbox B over IP)**

**Status before this PR**: On the Feb 2026 stack, sandboxes shared the runner's default `docker0` bridge with `enable_icc: true`. PR #45 tried to fix it by inserting `iptables -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP` via a sidecar. That rule only fires when the host has the `br_netfilter` kernel module loaded — default GCP Ubuntu 24.04 does **not** load it, so the rule was silently a no-op (verified on wei-tapp2: pkts=0 after 20+ minutes). Sandbox A could reach sandbox B on any port.

**Fix**: `INTER_SANDBOX_NETWORK_ENABLED=false` on the runner service (v0.189 native). daytona-runner now creates a dedicated bridge `runner-bridge` with `com.docker.network.bridge.enable_icc: false`, and spawns every sandbox on it. dockerd itself drops container-to-container packets on that bridge — no host kernel module needed. The old `runner-firewall` sidecar is removed.

Verified:
```
# From sandbox B (running python3 -m http.server 9000 on sandbox A):
curl http://<sandbox-A-ip>:9000/  → Connection timed out (HTTP 000, exit 28)
bash -c 'echo > /dev/tcp/<sandbox-A-ip>/9000'  → TCP-BLOCKED
```

**Q2b — Filesystem / process path (sandbox A reads sandbox B's files or processes)**

**Status before this PR**: Blocked by standard Docker container namespacing — each sandbox has its own PID, mount, IPC, user, UTS namespaces. `Privileged: true` grants full capabilities *within* the container's own namespaces; it does not let one container see into another container's private namespaces.

This PR does not change that behavior. What it verifies (and what a design review should check):
- `/var/run/docker.sock` is **not** mounted into user sandboxes — a compromised sandbox cannot use the Docker API to `docker exec` into a sibling. Confirmed: `ls -la /var/run/docker.sock` inside a running sandbox returns `No such file or directory`.
- Sandboxes don't share writable volumes with each other. Only per-sandbox volumes are mounted (verified via `docker inspect` on user containers).

**Residual risk**:
- If a future change accidentally mounts docker.sock into a sandbox (for e.g. dev-mode "run docker in your sandbox" feature), Q2b re-opens completely. Worth a linting check.

### Summary matrix

| Attack | Before PR #51 | After PR #51 | Enforced by |
|---|---|---|---|
| sandbox root → host root | Open | **Blocked** | Sysbox user-ns (host kernel) |
| sandbox A network → sandbox B network | Effectively open (br_netfilter not loaded) | **Blocked** | dockerd icc=false on runner-bridge |
| sandbox A fs / processes → sandbox B | Blocked | Blocked | Docker container namespaces (unchanged) |
| sandbox → spawn privileged sibling container via docker.sock | N/A (socket not mounted) | N/A | Daytona-runner default (unchanged) |

### Host-side prerequisite

`sysbox-runc` must be registered as a runtime in the host's `/etc/docker/daemon.json`, and the host must run Sysbox 0.7.0+ against Docker 27.x (Sysbox has not yet released a version compatible with Docker 28+ — see the [0g-tapp#5 review comment](https://github.com/0gfoundation/0g-tapp/pull/5#issuecomment-4865644935)). If those aren't in place, `docker compose up` on the runner fails with `unknown or invalid runtime name: sysbox-runc` — safe-fail rather than silent-fall-back.

---

## Test plan (end-to-end on wei-tapp2, a real testnet tapp deployment)
- [x] fresh v0.189 install: `grant-admin-perms` skipped (idempotent guard), full lifecycle ok
- [x] Feb 2026 → v0.189 upgrade with pre-existing sandboxes: `pg_dump` → change tags → `docker compose up -d` → migrations auto-run (65 → 111) → `grant-admin-perms` fires (`UPDATE 1`) → `class` → `sandboxClass` schema migration preserves data → old sandbox start/stop still work → new sandbox creates cleanly
- [x] Rollback via `pg_dump` restore + revert tags → schema back to `class`, old sandbox intact
- [x] ssh-access, toolbox on normal sandbox → 200; on sealed sandbox → 403
- [x] owner-scoped list and admin sandbox_list both return correct count after pagination fix
- [x] real chain settlement: 4 vouchers settled on-chain via settleFeesWithTEE, provider earnings updated
- [x] stop→start preserves user data (`/home/daytona/marker.txt` survives)
- [x] **Q1 verified**: runner container `Runtime=sysbox-runc`, uid_map `0 362144 65536`; user sandbox uid_map also remapped; `sudo mount --bind /` inside sandbox mounts within nested user-ns only, no visibility into host `/`
- [x] **Q2a verified**: `curl http://<sandbox-A-ip>:9000/` from sandbox B → `Connection timed out`; raw `bash /dev/tcp/<A>/9000` → `TCP-BLOCKED`
- [x] **Q2b verified**: `/var/run/docker.sock` not present in sandbox; sandboxes have independent PID/mount namespaces
- [x] sealed sandbox: image content digest resolved, `SANDBOX_SEAL_ATTESTATION` env injected, `0g-sealed:true` label set, ssh-access + toolbox blocked at billing-proxy
- [x] `go build ./...` + `go test ./internal/daytona/... ./internal/proxy/...`

## Follow-up (out of scope, filed as [PR comment](https://github.com/0gfoundation/0g-sandbox/pull/51#issuecomment-4865633436))
Move to drop-DinD for Sysbox at the inner (user sandbox) boundary would additionally isolate user containers from the runner itself, but requires resolving the internal registry reachability question. This PR takes the outer-boundary approach because it needs no other topology changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)