### PR TITLE
feat(compose): parameterize sandbox image via SANDBOX_IMAGE

### DIFF
--- a/docker/sandbox/.env.example
+++ b/docker/sandbox/.env.example
@@ -1,4 +1,12 @@
 # ── Billing proxy ─────────────────────────────────────────────────────────────
+# Sandbox proxy image. Set to a registry the host can reach; unset falls back to
+# the aliyun VPC ref (only reachable inside that VPC). For GCP CVMs use the GCP
+# Artifact Registry copy, e.g.:
+#   SANDBOX_IMAGE=us-central1-docker.pkg.dev/g-devops/zg-sandbox/0g-sandbox:sandbox
+# Pull auth for private registries is set up out-of-band via `tapp-cli docker-login`
+# (for AR: user oauth2accesstoken, password = `gcloud auth print-access-token`).
+SANDBOX_IMAGE=
+
 # DAYTONA_API_URL is hardcoded in docker-compose.yml (http://api:3000).
 # Do NOT set it here — Daytona must not be reachable from outside the stack.
 DAYTONA_ADMIN_KEY=          # Daytona admin API key (set in Daytona's ADMIN_API_KEY)

--- a/docker/sandbox/docker-compose.yml
+++ b/docker/sandbox/docker-compose.yml
@@ -2,7 +2,10 @@ services:
 
   # ── Sandbox proxy (this repo) ──────────────────────────────────────────────
   sandbox:
-    image: eliza-registry-vpc.ap-southeast-1.cr.aliyuncs.com/eliza/0g-sandbox:sandbox
+    # Registry-agnostic: set SANDBOX_IMAGE in .env to a registry the host can reach
+    # (e.g. GCP Artifact Registry for GCP CVMs; the aliyun VPC registry is only
+    # reachable from inside that VPC). Falls back to the aliyun ref if unset.
+    image: ${SANDBOX_IMAGE:-eliza-registry-vpc.ap-southeast-1.cr.aliyuncs.com/eliza/0g-sandbox:sandbox}
     pull_policy: always
     ports:
       - "${PORT:-8080}:8080"


### PR DESCRIPTION
## Problem

The `sandbox` service image was hardcoded to the aliyun VPC registry:
```
image: eliza-registry-vpc.ap-southeast-1.cr.aliyuncs.com/eliza/0g-sandbox:sandbox
```
That endpoint only resolves/connects **inside the aliyun VPC**. On GCP CVMs (e.g. wei-tapp) it's unreachable — DNS `no such host` for the `-vpc` ref, and the public aliyun endpoint times out from GCP. The only way to deploy there was to `docker build` the image locally on each host and set `pull_policy: never` — not reproducible, and it breaks a fresh CVM (no image present).

## Change

Make the image reference an env var with the aliyun ref as default:
```yaml
image: ${SANDBOX_IMAGE:-eliza-registry-vpc.ap-southeast-1.cr.aliyuncs.com/eliza/0g-sandbox:sandbox}
pull_policy: always
```
Each deployment sets `SANDBOX_IMAGE` in `.env` to a registry its host can reach. `.env.example` documents it, including the GCP Artifact Registry copy for GCP CVMs.

- Compose **text is identical across hosts** → stable `composeHash` for TappRegistry.
- The image **content digest** is the same wherever it's mirrored → `imageHashes` unaffected.
- Drops the per-host local-build + `pull_policy: never` workaround.

## Verified end-to-end (GCP CVM, us-central1)

- Pushed the image to a new AR repo `us-central1-docker.pkg.dev/g-devops/zg-sandbox/0g-sandbox:sandbox`.
- Set `SANDBOX_IMAGE` to that ref, `tapp-cli docker-login` with a short-lived `gcloud auth print-access-token`, removed the local image, `start-app`.
- Sandbox container came up **pulled from AR** (verified `docker ps` image ref), all 12 services healthy, billing proxy `signer: aligned`.

## Notes / follow-ups

- **Pull auth**: AR is private; the CVM instance service account lacks the AR scope, and creating a dedicated reader SA key is currently blocked by IAM. So pull auth is done out-of-band per deploy via `tapp-cli docker-login` with a ~1h token — fine for attended deploys. Unattended auto-pull would need an AR Reader SA key (admin action) or a public mirror.
- Related host prerequisite (`br_netfilter`) documented in the PR #51 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)