### PR TITLE
feat(serving): let an appOwner delegate a service to another provider wallet

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -2,7 +2,9 @@
 //
 // Subcommands:
 //
-//	register       Bind URL, prices, and createFee to an appId in SandboxServing
+//	register         Bind URL, prices, and createFee to an appId in SandboxServing
+//	authorize-provider  Delegate commercial service management for an appId to another wallet
+//	revoke-provider     Revoke a previously delegated provider's authorization
 //	status         Show provider registration and earnings
 //	withdraw       Withdraw accumulated earnings
 //	push-image     Load a local Docker image into the internal registry via the runner
@@ -61,7 +63,7 @@ const (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: provider <subcommand> [flags]")
-		fmt.Fprintln(os.Stderr, "  subcommands: register | deregister | status | withdraw | push-image | snapshot | snapshots | delete-snapshot | gc-images")
+		fmt.Fprintln(os.Stderr, "  subcommands: register | deregister | authorize-provider | revoke-provider | status | withdraw | push-image | snapshot | snapshots | delete-snapshot | gc-images")
 		os.Exit(1)
 	}
 
@@ -70,6 +72,10 @@ func main() {
 		runRegister(os.Args[2:])
 	case "deregister":
 		runDeregister(os.Args[2:])
+	case "authorize-provider":
+		runAuthorizeProvider(os.Args[2:])
+	case "revoke-provider":
+		runRevokeProvider(os.Args[2:])
 	case "status":
 		runStatus(os.Args[2:])
 	case "withdraw":
@@ -86,7 +92,7 @@ func main() {
 		runGCImages(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n", os.Args[1])
-		fmt.Fprintln(os.Stderr, "  subcommands: register | deregister | status | withdraw | push-image | snapshot | snapshots | delete-snapshot | gc-images")
+		fmt.Fprintln(os.Stderr, "  subcommands: register | deregister | authorize-provider | revoke-provider | status | withdraw | push-image | snapshot | snapshots | delete-snapshot | gc-images")
 		os.Exit(1)
 	}
 }
@@ -198,6 +204,104 @@ func runDeregister(args []string) {
 	fmt.Printf("\nDone. Service cleared. Re-run `register` with the new appId.\n")
 }
 
+// ── authorize-provider ───────────────────────────────────────────────────────
+
+// runAuthorizeProvider delegates commercial service management for appId to
+// another wallet. --key/PROVIDER_KEY here must be the appId's TappRegistry
+// owner key, NOT the delegate's — the contract checks msg.sender against
+// tappRegistry.getAppInfo(appId).owner.
+func runAuthorizeProvider(args []string) {
+	fs := flag.NewFlagSet("authorize-provider", flag.ExitOnError)
+	rpc         := fs.String("rpc",      defaultRPC,      "RPC endpoint")
+	chainID     := fs.Int64("chain-id",  defaultChainID,  "Chain ID")
+	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
+	keyHex      := fs.String("key",      "",              "App owner private key (hex); or set PROVIDER_KEY env — must be the appId's TappRegistry owner")
+	appId       := fs.String("app-id",   "",              "TappRegistry appId to delegate (required)")
+	providerHex := fs.String("provider", "",              "Wallet to authorize as a delegate provider (required)")
+	_ = fs.Parse(args)
+
+	if *appId == "" {
+		fatalf("--app-id is required")
+	}
+	if *providerHex == "" {
+		fatalf("--provider is required")
+	}
+	privKey := resolveKey(*keyHex, "PROVIDER_KEY")
+	appOwnerAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	providerAddr := common.HexToAddress(*providerHex)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	eth, contract := dialContract(ctx, *rpc, *contractHex)
+	defer eth.Close()
+
+	fmt.Printf("App owner: %s\n", appOwnerAddr.Hex())
+	fmt.Printf("AppId:     %s\n", *appId)
+	fmt.Printf("Delegate:  %s\n", providerAddr.Hex())
+
+	auth := buildAuth(ctx, privKey, *chainID)
+	fmt.Println("\n[1/1] AuthorizeProvider...")
+	tx, err := contract.AuthorizeProvider(auth, *appId, providerAddr)
+	if err != nil {
+		fatalf("AuthorizeProvider: %v\n\nReminder: --key must be the appId's TappRegistry owner, not the delegate.", err)
+	}
+	fmt.Printf("      tx: %s\n", tx.Hash().Hex())
+	if _, err := bind.WaitMined(ctx, eth, tx); err != nil {
+		fatalf("wait mined: %v", err)
+	}
+	fmt.Println("      confirmed ✓")
+	fmt.Printf("\nDone. %s can now run `register --app-id %s ...` with its own key.\n", providerAddr.Hex(), *appId)
+}
+
+// ── revoke-provider ───────────────────────────────────────────────────────────
+
+// runRevokeProvider revokes a delegate's authorization for appId. Soft revoke:
+// blocks further `register` calls from the delegate, but its existing service,
+// balance, nonce, and earnings are untouched. To cut off voucher-signing
+// ability, remove the delegate as a TappRegistry node instead.
+func runRevokeProvider(args []string) {
+	fs := flag.NewFlagSet("revoke-provider", flag.ExitOnError)
+	rpc         := fs.String("rpc",      defaultRPC,      "RPC endpoint")
+	chainID     := fs.Int64("chain-id",  defaultChainID,  "Chain ID")
+	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
+	keyHex      := fs.String("key",      "",              "App owner private key (hex); or set PROVIDER_KEY env — must be the appId's TappRegistry owner")
+	appId       := fs.String("app-id",   "",              "TappRegistry appId (required)")
+	providerHex := fs.String("provider", "",              "Delegate wallet to revoke (required)")
+	_ = fs.Parse(args)
+
+	if *appId == "" {
+		fatalf("--app-id is required")
+	}
+	if *providerHex == "" {
+		fatalf("--provider is required")
+	}
+	privKey := resolveKey(*keyHex, "PROVIDER_KEY")
+	appOwnerAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	providerAddr := common.HexToAddress(*providerHex)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	eth, contract := dialContract(ctx, *rpc, *contractHex)
+	defer eth.Close()
+
+	fmt.Printf("App owner: %s\n", appOwnerAddr.Hex())
+	fmt.Printf("AppId:     %s\n", *appId)
+	fmt.Printf("Delegate:  %s\n", providerAddr.Hex())
+
+	auth := buildAuth(ctx, privKey, *chainID)
+	fmt.Println("\n[1/1] RevokeProvider...")
+	tx, err := contract.RevokeProvider(auth, *appId, providerAddr)
+	if err != nil {
+		fatalf("RevokeProvider: %v", err)
+	}
+	fmt.Printf("      tx: %s\n", tx.Hash().Hex())
+	if _, err := bind.WaitMined(ctx, eth, tx); err != nil {
+		fatalf("wait mined: %v", err)
+	}
+	fmt.Println("      confirmed ✓")
+	fmt.Printf("\nDone. %s can no longer update pricing for %s (its existing service keeps settling).\n", providerAddr.Hex(), *appId)
+}
+
 // ── status ────────────────────────────────────────────────────────────────────
 
 func runStatus(args []string) {
@@ -206,6 +310,7 @@ func runStatus(args []string) {
 	contractHex := fs.String("contract", envOrDefault("SETTLEMENT_CONTRACT", ""), "Settlement contract address (required: --contract or SETTLEMENT_CONTRACT env)")
 	keyHex      := fs.String("key",      "",              "Provider private key; or set PROVIDER_KEY env")
 	addrHex     := fs.String("address",  "",              "Provider address (alternative to --key)")
+	tappHex     := fs.String("tapp",     envOrDefault("TAPP_REGISTRY", ""), "TappRegistry address (optional; shows whether this address is the appId owner or a delegate)")
 	_ = fs.Parse(args)
 
 	var providerAddr common.Address
@@ -254,6 +359,22 @@ func runStatus(args []string) {
 		fmt.Printf("  Create fee:       %s neuron\n", svc.CreateFee.String())
 		fmt.Printf("  Earnings:         %s neuron\n", earnings.String())
 		fmt.Println("  (TEE signers + ack state now live in TappRegistry; query that contract for cluster info.)")
+
+		if *tappHex != "" && svc.AppId != "" {
+			tapp, err := chain.NewTappRegistry(common.HexToAddress(*tappHex), eth)
+			if err != nil {
+				fatalf("bind tappRegistry: %v", err)
+			}
+			appInfo, err := tapp.GetAppInfo(opts, svc.AppId)
+			if err != nil {
+				fatalf("tapp.getAppInfo: %v", err)
+			}
+			if appInfo.Owner == providerAddr {
+				fmt.Println("  Role:             app owner (self-registered)")
+			} else {
+				fmt.Printf("  Role:             delegate provider (app owner: %s)\n", appInfo.Owner.Hex())
+			}
+		}
 	}
 }
 

--- a/contracts/abi/SandboxServing.json
+++ b/contracts/abi/SandboxServing.json
@@ -52,6 +52,48 @@
   },
   {
     "type": "function",
+    "name": "authorizeProvider",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "authorizedProviders",
+    "inputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "balanceOfBatch",
     "inputs": [
       {
@@ -329,6 +371,24 @@
   },
   {
     "type": "function",
+    "name": "revokeProvider",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "serviceExists",
     "inputs": [
       {
@@ -557,6 +617,56 @@
       },
       {
         "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderAuthorized",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderRevoked",
+    "inputs": [
+      {
+        "name": "appId",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "appOwner",
         "type": "address",
         "indexed": true,
         "internalType": "address"

--- a/contracts/src/SandboxServing.sol
+++ b/contracts/src/SandboxServing.sol
@@ -110,8 +110,14 @@ contract SandboxServing {
     ///         TappRegistry is itself redeployed.
     ITappRegistry public tappRegistry;
 
+    /// @notice appId => delegate provider address => authorized. Lets an appId's
+    ///         TappRegistry owner delegate commercial service management
+    ///         (pricing/URL/balance/earnings) to another wallet without making
+    ///         that wallet the TappRegistry owner. See addOrUpdateService.
+    mapping(string => mapping(address => bool)) public authorizedProviders;
+
     // Reserved for future upgrades.
-    uint256[50] private __gap;
+    uint256[49] private __gap;
 
     // ─── Events ───────────────────────────────────────────────────────────────
 
@@ -129,6 +135,8 @@ contract SandboxServing {
     event EarningsWithdrawn(address indexed provider, uint256 amount);
     event ServiceUpdated(address indexed provider, string appId, string url);
     event ServiceDeregistered(address indexed provider);
+    event ProviderAuthorized(string appId, address indexed provider, address indexed appOwner);
+    event ProviderRevoked(string appId, address indexed provider, address indexed appOwner);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event TappRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
 
@@ -365,8 +373,9 @@ contract SandboxServing {
 
     // ─── Provider Management ──────────────────────────────────────────────────
 
-    /// @notice Register or update a provider service. Caller must already own
-    ///         the appId in TappRegistry, and must have authorized this contract
+    /// @notice Register or update a provider service. Caller must either own
+    ///         the appId in TappRegistry, or have been delegated via
+    ///         authorizeProvider, and must have authorized this contract
     ///         as an invalidator (see ITappRegistry.authorizeInvalidator).
     /// @dev appId is set-once on first call; later updates must pass the same
     ///      appId or revert. Stake is collected by TappRegistry (per node);
@@ -383,7 +392,11 @@ contract SandboxServing {
         uint256 createFee,
         uint256 pricePerMemGBPerMin
     ) external {
-        require(tappRegistry.getAppInfo(appId).owner == msg.sender, "not app owner");
+        address appOwner_ = tappRegistry.getAppInfo(appId).owner;
+        require(
+            msg.sender == appOwner_ || authorizedProviders[appId][msg.sender],
+            "not app owner or authorized provider"
+        );
         require(
             tappRegistry.isAuthorizedInvalidator(appId, address(this)),
             "sandbox not authorized as invalidator"
@@ -432,6 +445,32 @@ contract SandboxServing {
         delete services[msg.sender];
         serviceExists[msg.sender] = false;
         emit ServiceDeregistered(msg.sender);
+    }
+
+    /// @notice Delegate commercial service management for appId to another
+    ///         wallet. Callable only by the appId's current TappRegistry owner.
+    /// @dev Purely administrative: it only gates future addOrUpdateService
+    ///      calls. It does not affect voucher settlement, which validates
+    ///      signatures against TappRegistry's live node list regardless of
+    ///      who manages the commercial listing.
+    function authorizeProvider(string calldata appId, address provider) external {
+        require(tappRegistry.getAppInfo(appId).owner == msg.sender, "not app owner");
+        require(provider != address(0), "zero provider");
+        authorizedProviders[appId][provider] = true;
+        emit ProviderAuthorized(appId, provider, msg.sender);
+    }
+
+    /// @notice Revoke a previously delegated provider's authorization for appId.
+    /// @dev Soft revoke: blocks further addOrUpdateService calls from `provider`
+    ///      for this appId, but does not touch its existing service entry,
+    ///      balance, nonce, or earnings — those keep working. To fully cut off
+    ///      a bad actor's ability to sign vouchers, remove them as a TappRegistry
+    ///      node instead (remove-node-onchain); that is the real security
+    ///      boundary for settlement.
+    function revokeProvider(string calldata appId, address provider) external {
+        require(tappRegistry.getAppInfo(appId).owner == msg.sender, "not app owner");
+        authorizedProviders[appId][provider] = false;
+        emit ProviderRevoked(appId, provider, msg.sender);
     }
 
     // ─── View Functions ───────────────────────────────────────────────────────

--- a/contracts/src/SandboxServing.t.sol
+++ b/contracts/src/SandboxServing.t.sol
@@ -339,8 +339,8 @@ contract SandboxServingTest is Test {
 
     function test_AddService_RejectsNonAppOwner() public {
         address impostor = makeAddr("impostor");
-        // impostor does NOT own APP_ID in tap
-        vm.expectRevert("not app owner");
+        // impostor does NOT own APP_ID in tap, and was never authorized as a delegate
+        vm.expectRevert("not app owner or authorized provider");
         vm.prank(impostor);
         serving.addOrUpdateService("u", APP_ID, 1, 1, 1);
     }
@@ -378,6 +378,89 @@ contract SandboxServingTest is Test {
         vm.prank(provider);
         serving.addOrUpdateService("new-url", APP_ID, 1000, 5000, 500); // only URL changed
         assertEq(tap.invalidateCount(), before, "URL change must not invalidate acks");
+    }
+
+    // ── Delegated providers ──────────────────────────────────────────────────
+
+    function test_AuthorizeProvider_AllowsDelegateToRegisterOwnService() public {
+        address delegate = makeAddr("delegate");
+
+        vm.prank(provider);
+        serving.authorizeProvider(APP_ID, delegate);
+        assertTrue(serving.authorizedProviders(APP_ID, delegate));
+
+        vm.prank(delegate);
+        serving.addOrUpdateService("https://delegate.example.com", APP_ID, 2000, 6000, 700);
+
+        assertTrue(serving.serviceExists(delegate));
+        (, string memory delegateAppId,,,) = serving.services(delegate);
+        assertEq(delegateAppId, APP_ID);
+
+        // Delegate's balance/nonce/earnings are independent of the app owner's.
+        vm.prank(user);
+        serving.deposit{value: 1 ether}(user, delegate);
+        tap.setAck(user, APP_ID, true);
+
+        vm.prank(delegate);
+        SandboxServing.SandboxVoucher[] memory vs = new SandboxServing.SandboxVoucher[](1);
+        vs[0] = _makeVoucher(user, delegate, 1000, keccak256("delegate-usage"), 1);
+        SandboxServing.SettlementStatus[] memory statuses = serving.settleFeesWithTEE(vs);
+        assertEq(uint8(statuses[0]), uint8(SandboxServing.SettlementStatus.SUCCESS));
+
+        assertEq(serving.getProviderEarnings(delegate), 1000);
+        assertEq(serving.getProviderEarnings(provider), 0); // app owner's own earnings untouched
+        (uint256 delegateBal,,) = serving.getBalance(user, delegate);
+        (uint256 providerBal,,) = serving.getBalance(user, provider);
+        assertEq(delegateBal, 1 ether - 1000);
+        assertEq(providerBal, 0); // no shared pool — user never deposited to `provider`
+    }
+
+    function test_AuthorizeProvider_RejectsNonAppOwnerCaller() public {
+        address impostor = makeAddr("impostor");
+        address delegate = makeAddr("delegate");
+        vm.expectRevert("not app owner");
+        vm.prank(impostor);
+        serving.authorizeProvider(APP_ID, delegate);
+    }
+
+    function test_AuthorizeProvider_RejectsZeroAddress() public {
+        vm.expectRevert("zero provider");
+        vm.prank(provider);
+        serving.authorizeProvider(APP_ID, address(0));
+    }
+
+    function test_RevokeProvider_BlocksFurtherRegisterButKeepsExistingService() public {
+        address delegate = makeAddr("delegate");
+        vm.prank(provider);
+        serving.authorizeProvider(APP_ID, delegate);
+        vm.prank(delegate);
+        serving.addOrUpdateService("https://delegate.example.com", APP_ID, 2000, 6000, 700);
+
+        vm.prank(provider);
+        serving.revokeProvider(APP_ID, delegate);
+        assertFalse(serving.authorizedProviders(APP_ID, delegate));
+
+        vm.expectRevert("not app owner or authorized provider");
+        vm.prank(delegate);
+        serving.addOrUpdateService("https://delegate.example.com", APP_ID, 3000, 6000, 700);
+
+        // Existing service keeps settling — revocation is administrative only.
+        vm.prank(user);
+        serving.deposit{value: 1 ether}(user, delegate);
+        tap.setAck(user, APP_ID, true);
+        vm.prank(delegate);
+        SandboxServing.SandboxVoucher[] memory vs = new SandboxServing.SandboxVoucher[](1);
+        vs[0] = _makeVoucher(user, delegate, 500, keccak256("post-revoke-usage"), 1);
+        SandboxServing.SettlementStatus[] memory statuses = serving.settleFeesWithTEE(vs);
+        assertEq(uint8(statuses[0]), uint8(SandboxServing.SettlementStatus.SUCCESS));
+    }
+
+    function test_RevokeProvider_RejectsNonAppOwnerCaller() public {
+        address impostor = makeAddr("impostor");
+        address delegate = makeAddr("delegate");
+        vm.expectRevert("not app owner");
+        vm.prank(impostor);
+        serving.revokeProvider(APP_ID, delegate);
     }
 
     function test_IsTEEAcknowledged_Shim() public {

--- a/internal/chain/sandbox_serving.go
+++ b/internal/chain/sandbox_serving.go
@@ -41,7 +41,7 @@ type SandboxServingSandboxVoucher struct {
 
 // SandboxServingMetaData contains all meta data concerning the SandboxServing contract.
 var SandboxServingMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"LOCK_TIME\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"addOrUpdateService\",\"inputs\":[{\"name\":\"url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"pricePerCPUPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"createFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pricePerMemGBPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"balanceOfBatch\",\"inputs\":[{\"name\":\"users\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"balances\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"deregisterService\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"domainSeparator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getBalance\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pendingRefund\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"refundUnlockAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getLastNonce\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderEarnings\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"tappRegistry_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isTEEAcknowledged\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"previewSettlementResults\",\"inputs\":[{\"name\":\"vouchers\",\"type\":\"tuple[]\",\"internalType\":\"structSandboxServing.SandboxVoucher[]\",\"components\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"statuses\",\"type\":\"uint8[]\",\"internalType\":\"enumSandboxServing.SettlementStatus[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerEarnings\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"requestRefund\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"serviceExists\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"services\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"pricePerCPUPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pricePerMemGBPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"createFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setTappRegistry\",\"inputs\":[{\"name\":\"newRegistry\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"settleFeesWithTEE\",\"inputs\":[{\"name\":\"vouchers\",\"type\":\"tuple[]\",\"internalType\":\"structSandboxServing.SandboxVoucher[]\",\"components\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"statuses\",\"type\":\"uint8[]\",\"internalType\":\"enumSandboxServing.SettlementStatus[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"tappRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractITappRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"withdrawEarnings\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"withdrawRefund\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Deposited\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EarningsWithdrawn\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RefundRequested\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"unlockAt\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RefundWithdrawn\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ServiceDeregistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ServiceUpdated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appId\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"url\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TappRegistryUpdated\",\"inputs\":[{\"name\":\"previousRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VoucherSettled\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"status\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumSandboxServing.SettlementStatus\"}],\"anonymous\":false}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"LOCK_TIME\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"addOrUpdateService\",\"inputs\":[{\"name\":\"url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"pricePerCPUPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"createFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pricePerMemGBPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"authorizeProvider\",\"inputs\":[{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"authorizedProviders\",\"inputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"balanceOfBatch\",\"inputs\":[{\"name\":\"users\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"balances\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"deregisterService\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"domainSeparator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getBalance\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pendingRefund\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"refundUnlockAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getLastNonce\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderEarnings\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"tappRegistry_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isTEEAcknowledged\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"previewSettlementResults\",\"inputs\":[{\"name\":\"vouchers\",\"type\":\"tuple[]\",\"internalType\":\"structSandboxServing.SandboxVoucher[]\",\"components\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"statuses\",\"type\":\"uint8[]\",\"internalType\":\"enumSandboxServing.SettlementStatus[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerEarnings\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"requestRefund\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeProvider\",\"inputs\":[{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"serviceExists\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"services\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"url\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"appId\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"pricePerCPUPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pricePerMemGBPerMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"createFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setTappRegistry\",\"inputs\":[{\"name\":\"newRegistry\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"settleFeesWithTEE\",\"inputs\":[{\"name\":\"vouchers\",\"type\":\"tuple[]\",\"internalType\":\"structSandboxServing.SandboxVoucher[]\",\"components\":[{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"statuses\",\"type\":\"uint8[]\",\"internalType\":\"enumSandboxServing.SettlementStatus[]\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"tappRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractITappRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"withdrawEarnings\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"withdrawRefund\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Deposited\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EarningsWithdrawn\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderAuthorized\",\"inputs\":[{\"name\":\"appId\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderRevoked\",\"inputs\":[{\"name\":\"appId\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RefundRequested\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"unlockAt\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RefundWithdrawn\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ServiceDeregistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ServiceUpdated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appId\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"url\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TappRegistryUpdated\",\"inputs\":[{\"name\":\"previousRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VoucherSettled\",\"inputs\":[{\"name\":\"user\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"totalFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"usageHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"status\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumSandboxServing.SettlementStatus\"}],\"anonymous\":false}]",
 }
 
 // SandboxServingABI is the input ABI used to generate the binding from.
@@ -219,6 +219,37 @@ func (_SandboxServing *SandboxServingSession) LOCKTIME() (*big.Int, error) {
 // Solidity: function LOCK_TIME() view returns(uint256)
 func (_SandboxServing *SandboxServingCallerSession) LOCKTIME() (*big.Int, error) {
 	return _SandboxServing.Contract.LOCKTIME(&_SandboxServing.CallOpts)
+}
+
+// AuthorizedProviders is a free data retrieval call binding the contract method 0x6004711a.
+//
+// Solidity: function authorizedProviders(string , address ) view returns(bool)
+func (_SandboxServing *SandboxServingCaller) AuthorizedProviders(opts *bind.CallOpts, arg0 string, arg1 common.Address) (bool, error) {
+	var out []interface{}
+	err := _SandboxServing.contract.Call(opts, &out, "authorizedProviders", arg0, arg1)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// AuthorizedProviders is a free data retrieval call binding the contract method 0x6004711a.
+//
+// Solidity: function authorizedProviders(string , address ) view returns(bool)
+func (_SandboxServing *SandboxServingSession) AuthorizedProviders(arg0 string, arg1 common.Address) (bool, error) {
+	return _SandboxServing.Contract.AuthorizedProviders(&_SandboxServing.CallOpts, arg0, arg1)
+}
+
+// AuthorizedProviders is a free data retrieval call binding the contract method 0x6004711a.
+//
+// Solidity: function authorizedProviders(string , address ) view returns(bool)
+func (_SandboxServing *SandboxServingCallerSession) AuthorizedProviders(arg0 string, arg1 common.Address) (bool, error) {
+	return _SandboxServing.Contract.AuthorizedProviders(&_SandboxServing.CallOpts, arg0, arg1)
 }
 
 // BalanceOfBatch is a free data retrieval call binding the contract method 0x8a921690.
@@ -662,6 +693,27 @@ func (_SandboxServing *SandboxServingTransactorSession) AddOrUpdateService(url s
 	return _SandboxServing.Contract.AddOrUpdateService(&_SandboxServing.TransactOpts, url, appId, pricePerCPUPerMin, createFee, pricePerMemGBPerMin)
 }
 
+// AuthorizeProvider is a paid mutator transaction binding the contract method 0x2458af06.
+//
+// Solidity: function authorizeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingTransactor) AuthorizeProvider(opts *bind.TransactOpts, appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.contract.Transact(opts, "authorizeProvider", appId, provider)
+}
+
+// AuthorizeProvider is a paid mutator transaction binding the contract method 0x2458af06.
+//
+// Solidity: function authorizeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingSession) AuthorizeProvider(appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.Contract.AuthorizeProvider(&_SandboxServing.TransactOpts, appId, provider)
+}
+
+// AuthorizeProvider is a paid mutator transaction binding the contract method 0x2458af06.
+//
+// Solidity: function authorizeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingTransactorSession) AuthorizeProvider(appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.Contract.AuthorizeProvider(&_SandboxServing.TransactOpts, appId, provider)
+}
+
 // Deposit is a paid mutator transaction binding the contract method 0xf9609f08.
 //
 // Solidity: function deposit(address recipient, address provider) payable returns()
@@ -744,6 +796,27 @@ func (_SandboxServing *SandboxServingSession) RequestRefund(provider common.Addr
 // Solidity: function requestRefund(address provider, uint256 amount) returns()
 func (_SandboxServing *SandboxServingTransactorSession) RequestRefund(provider common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _SandboxServing.Contract.RequestRefund(&_SandboxServing.TransactOpts, provider, amount)
+}
+
+// RevokeProvider is a paid mutator transaction binding the contract method 0x53ded3f8.
+//
+// Solidity: function revokeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingTransactor) RevokeProvider(opts *bind.TransactOpts, appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.contract.Transact(opts, "revokeProvider", appId, provider)
+}
+
+// RevokeProvider is a paid mutator transaction binding the contract method 0x53ded3f8.
+//
+// Solidity: function revokeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingSession) RevokeProvider(appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.Contract.RevokeProvider(&_SandboxServing.TransactOpts, appId, provider)
+}
+
+// RevokeProvider is a paid mutator transaction binding the contract method 0x53ded3f8.
+//
+// Solidity: function revokeProvider(string appId, address provider) returns()
+func (_SandboxServing *SandboxServingTransactorSession) RevokeProvider(appId string, provider common.Address) (*types.Transaction, error) {
+	return _SandboxServing.Contract.RevokeProvider(&_SandboxServing.TransactOpts, appId, provider)
 }
 
 // SetTappRegistry is a paid mutator transaction binding the contract method 0x57f6e4fc.
@@ -1306,6 +1379,314 @@ func (_SandboxServing *SandboxServingFilterer) WatchOwnershipTransferred(opts *b
 func (_SandboxServing *SandboxServingFilterer) ParseOwnershipTransferred(log types.Log) (*SandboxServingOwnershipTransferred, error) {
 	event := new(SandboxServingOwnershipTransferred)
 	if err := _SandboxServing.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SandboxServingProviderAuthorizedIterator is returned from FilterProviderAuthorized and is used to iterate over the raw logs and unpacked data for ProviderAuthorized events raised by the SandboxServing contract.
+type SandboxServingProviderAuthorizedIterator struct {
+	Event *SandboxServingProviderAuthorized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SandboxServingProviderAuthorizedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SandboxServingProviderAuthorized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SandboxServingProviderAuthorized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SandboxServingProviderAuthorizedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SandboxServingProviderAuthorizedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SandboxServingProviderAuthorized represents a ProviderAuthorized event raised by the SandboxServing contract.
+type SandboxServingProviderAuthorized struct {
+	AppId    string
+	Provider common.Address
+	AppOwner common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderAuthorized is a free log retrieval operation binding the contract event 0x4d74591d5b7b436fec8d2f5c8c5e100907522e4e2994631f171f9417770d245c.
+//
+// Solidity: event ProviderAuthorized(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) FilterProviderAuthorized(opts *bind.FilterOpts, provider []common.Address, appOwner []common.Address) (*SandboxServingProviderAuthorizedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var appOwnerRule []interface{}
+	for _, appOwnerItem := range appOwner {
+		appOwnerRule = append(appOwnerRule, appOwnerItem)
+	}
+
+	logs, sub, err := _SandboxServing.contract.FilterLogs(opts, "ProviderAuthorized", providerRule, appOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SandboxServingProviderAuthorizedIterator{contract: _SandboxServing.contract, event: "ProviderAuthorized", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderAuthorized is a free log subscription operation binding the contract event 0x4d74591d5b7b436fec8d2f5c8c5e100907522e4e2994631f171f9417770d245c.
+//
+// Solidity: event ProviderAuthorized(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) WatchProviderAuthorized(opts *bind.WatchOpts, sink chan<- *SandboxServingProviderAuthorized, provider []common.Address, appOwner []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var appOwnerRule []interface{}
+	for _, appOwnerItem := range appOwner {
+		appOwnerRule = append(appOwnerRule, appOwnerItem)
+	}
+
+	logs, sub, err := _SandboxServing.contract.WatchLogs(opts, "ProviderAuthorized", providerRule, appOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SandboxServingProviderAuthorized)
+				if err := _SandboxServing.contract.UnpackLog(event, "ProviderAuthorized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderAuthorized is a log parse operation binding the contract event 0x4d74591d5b7b436fec8d2f5c8c5e100907522e4e2994631f171f9417770d245c.
+//
+// Solidity: event ProviderAuthorized(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) ParseProviderAuthorized(log types.Log) (*SandboxServingProviderAuthorized, error) {
+	event := new(SandboxServingProviderAuthorized)
+	if err := _SandboxServing.contract.UnpackLog(event, "ProviderAuthorized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SandboxServingProviderRevokedIterator is returned from FilterProviderRevoked and is used to iterate over the raw logs and unpacked data for ProviderRevoked events raised by the SandboxServing contract.
+type SandboxServingProviderRevokedIterator struct {
+	Event *SandboxServingProviderRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SandboxServingProviderRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SandboxServingProviderRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SandboxServingProviderRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SandboxServingProviderRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SandboxServingProviderRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SandboxServingProviderRevoked represents a ProviderRevoked event raised by the SandboxServing contract.
+type SandboxServingProviderRevoked struct {
+	AppId    string
+	Provider common.Address
+	AppOwner common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderRevoked is a free log retrieval operation binding the contract event 0xcf0c28f6275e9bccdddfe2edd1ad4e6f615a3716ec829c7861f41bbdea6a381a.
+//
+// Solidity: event ProviderRevoked(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) FilterProviderRevoked(opts *bind.FilterOpts, provider []common.Address, appOwner []common.Address) (*SandboxServingProviderRevokedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var appOwnerRule []interface{}
+	for _, appOwnerItem := range appOwner {
+		appOwnerRule = append(appOwnerRule, appOwnerItem)
+	}
+
+	logs, sub, err := _SandboxServing.contract.FilterLogs(opts, "ProviderRevoked", providerRule, appOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SandboxServingProviderRevokedIterator{contract: _SandboxServing.contract, event: "ProviderRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderRevoked is a free log subscription operation binding the contract event 0xcf0c28f6275e9bccdddfe2edd1ad4e6f615a3716ec829c7861f41bbdea6a381a.
+//
+// Solidity: event ProviderRevoked(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) WatchProviderRevoked(opts *bind.WatchOpts, sink chan<- *SandboxServingProviderRevoked, provider []common.Address, appOwner []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var appOwnerRule []interface{}
+	for _, appOwnerItem := range appOwner {
+		appOwnerRule = append(appOwnerRule, appOwnerItem)
+	}
+
+	logs, sub, err := _SandboxServing.contract.WatchLogs(opts, "ProviderRevoked", providerRule, appOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SandboxServingProviderRevoked)
+				if err := _SandboxServing.contract.UnpackLog(event, "ProviderRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderRevoked is a log parse operation binding the contract event 0xcf0c28f6275e9bccdddfe2edd1ad4e6f615a3716ec829c7861f41bbdea6a381a.
+//
+// Solidity: event ProviderRevoked(string appId, address indexed provider, address indexed appOwner)
+func (_SandboxServing *SandboxServingFilterer) ParseProviderRevoked(log types.Log) (*SandboxServingProviderRevoked, error) {
+	event := new(SandboxServingProviderRevoked)
+	if err := _SandboxServing.contract.UnpackLog(event, "ProviderRevoked", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log


### PR DESCRIPTION
## Summary

- `SandboxServing.addOrUpdateService` today requires `msg.sender == tappRegistry.getAppInfo(appId).owner` — the wallet managing commercial terms (pricing/URL/balance/earnings) for an appId must be that appId's literal TappRegistry owner. Combined with `services` being keyed 1:1 by address, this means one wallet can never manage more than one service, and an appId can never be commercially represented by anyone but its owner.
- Adds `authorizeProvider(appId, provider)` / `revokeProvider(appId, provider)`, callable only by the appId's current TappRegistry owner, plus a public `authorizedProviders[appId][provider]` mapping. `addOrUpdateService`'s ownership check is relaxed to `msg.sender == appOwner || authorizedProviders[appId][msg.sender]`.
- Deliberately does **not** re-key `services`/`Account` (balances, nonces, refunds) from address to appId — each delegate still gets its own fully isolated service/balance/nonce entry, identical to a self-registered provider today. That sidesteps a real overcommit race a shared-balance design would introduce: two independently-deployed billing-proxy instances (each with its own Redis-based reservation admission control) can't see each other's pending reservations against a shared on-chain balance.
- Revocation is intentionally soft — it only blocks further `addOrUpdateService` calls from the delegate; existing balance/nonce/earnings/settlement are untouched. Cutting off a bad actor's ability to sign vouchers is TappRegistry's job (`remove-node-onchain`), not this contract's.
- Purely additive: no EIP-712/voucher change, no storage rekeying of existing state, no breaking upgrade — `__gap` shrinks 50→49 to make room for the new mapping, preserving upgrade-safe layout.
- `cmd/provider` gets two new subcommands: `authorize-provider --app-id --provider` and `revoke-provider --app-id --provider` (both signed by the app owner's key).

## Test plan

- [x] `make build-contracts && make abigen` — ABI/bindings regenerate cleanly
- [x] `go build ./...` — no downstream breakage
- [x] `go test ./...` — full existing suite passes unmodified
- [x] `make test-contracts` (Foundry) — 29/29 pass, including new cases: delegate registers its own isolated service, unauthorized third party rejected, revoke blocks further updates but not existing settlement, zero-address rejected, existing self-registration path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)