### PR TITLE
docs: document authorizeProvider/revokeProvider delegation (#56 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ cmd/
   deploy/     deploy beacon-proxy stack (3 steps: impl → beacon → proxy)
   upgrade/    upgrade via beacon.upgradeTo(newImpl)
   verify/     verify contracts on block explorer
-  provider/   provider CLI: register (binds appId), status, withdraw, snapshot management
+  provider/   provider CLI: register (binds appId), authorize/revoke-provider (delegation), status, withdraw, snapshot management
   user/       user CLI: create/stop/delete sandbox, exec, balance
   checkbal/   quick balance/nonce/earnings check for a private key
 internal/

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -106,9 +106,12 @@ Trust identity — the active TEE signer set and user acknowledgements — lives
 
 | Function | Notes |
 |---|---|
-| `addOrUpdateService(url, appId, pricePerCPUPerMin, createFee, pricePerMemGBPerMin)` | Register/update; `appId` set-once; caller must be the appId's TappRegistry owner |
+| `addOrUpdateService(url, appId, pricePerCPUPerMin, createFee, pricePerMemGBPerMin)` | Register/update; `appId` set-once; caller must be the appId's TappRegistry owner **or an authorized delegate** |
 | `deregisterService()` | Soft-clear the caller's service so `appId` can change; balances/earnings/nonces preserved |
 | `withdrawEarnings()` | Withdraw accrued settlement earnings |
+| `authorizeProvider(appId, provider)` | App owner only — delegate service management for `appId` to another wallet. The delegate registers its own fully isolated service entry (separate balances/nonces/earnings) |
+| `revokeProvider(appId, provider)` | App owner only — soft revoke: blocks further `addOrUpdateService` from the delegate; its existing service and settlement keep working. Cutting off voucher signing is TappRegistry's job (`remove-node-onchain`) |
+| `authorizedProviders(appId, provider)` → bool | view — delegation state |
 | `services(provider)` / `serviceExists(provider)` | view — commercial terms |
 | `getProviderEarnings(provider)` → uint256 | view |
 
@@ -128,7 +131,7 @@ Trust identity — the active TEE signer set and user acknowledgements — lives
 | `setTappRegistry(newRegistry)` | Repoint TappRegistry; ack state then reads from the new registry |
 | `tappRegistry()` / `domainSeparator()` / `LOCK_TIME()` | view |
 
-**Events:** `Deposited`, `RefundRequested`, `RefundWithdrawn`, `VoucherSettled`, `EarningsWithdrawn`, `ServiceUpdated`, `ServiceDeregistered`, `OwnershipTransferred`, `TappRegistryUpdated`.
+**Events:** `Deposited`, `RefundRequested`, `RefundWithdrawn`, `VoucherSettled`, `EarningsWithdrawn`, `ServiceUpdated`, `ServiceDeregistered`, `ProviderAuthorized`, `ProviderRevoked`, `OwnershipTransferred`, `TappRegistryUpdated`.
 
 ---
 
@@ -243,3 +246,4 @@ wallet holds enough 0G to pay gas for settlement.
 - **Open settlement** — `settleFeesWithTEE` can be called by anyone; the provider is identified by `v.provider` in the voucher, not `msg.sender`
 - **Trust root delegation** — SandboxServing holds only commercial terms; TEE signer identity and user acknowledgement live in TappRegistry and are queried on every voucher verification
 - **`appId` is set-once** — once `addOrUpdateService` has bound a non-empty `appId`, subsequent calls must pass the same value (a provider can only update URL / prices / createFee in place, not the trust root). To bind a *different* `appId`, call **`deregisterService`** first: a soft clear of the caller's service entry (url/appId/prices/createFee) that preserves user balances, pending refunds, settled nonces, and accrued `providerEarnings` — all still withdrawable — then re-register. Emits `ServiceDeregistered(provider)`.
+- **Provider delegation** — one appId can be commercially operated by multiple wallets: the app owner calls `authorizeProvider(appId, wallet)`, and each delegate registers its own service entry with fully isolated balances, nonces, and earnings (identical to a self-registered provider). Balances are deliberately **not** shared across delegates — independently deployed billing proxies each run their own reservation admission control and cannot see each other's pending reservations, so a shared on-chain balance would allow overcommit. Note the settlement boundary is per-appId, not per-delegate: any active TappRegistry node of the appId can sign vouchers for any of its delegates; the code identity (attested compose/image hashes) is what prevents cross-signing in practice.

--- a/contracts/README.zh.md
+++ b/contracts/README.zh.md
@@ -105,9 +105,12 @@ cast call <beacon> "owner()(address)"
 
 | 函数 | 说明 |
 |---|---|
-| `addOrUpdateService(url, appId, pricePerCPUPerMin, createFee, pricePerMemGBPerMin)` | 注册/更新;`appId` 写一次;调用者须是该 appId 的 TappRegistry owner |
+| `addOrUpdateService(url, appId, pricePerCPUPerMin, createFee, pricePerMemGBPerMin)` | 注册/更新;`appId` 写一次;调用者须是该 appId 的 TappRegistry owner **或被授权的委托 provider** |
 | `deregisterService()` | 软清除自己的 service,使 `appId` 可更换;余额/earnings/nonce 保留 |
 | `withdrawEarnings()` | 提取累计结算收益 |
+| `authorizeProvider(appId, provider)` | 仅 app owner — 把该 appId 的商业服务管理委托给另一个钱包;委托方注册自己完全独立的 service 条目(余额/nonce/earnings 互相隔离) |
+| `revokeProvider(appId, provider)` | 仅 app owner — 软撤销:只挡住该委托方后续的 `addOrUpdateService`,已有 service 和结算照常;要切断签 voucher 的能力去 TappRegistry 摘节点(`remove-node-onchain`) |
+| `authorizedProviders(appId, provider)` → bool | view — 委托状态 |
 | `services(provider)` / `serviceExists(provider)` | view — 业务条款 |
 | `getProviderEarnings(provider)` → uint256 | view |
 
@@ -127,7 +130,7 @@ cast call <beacon> "owner()(address)"
 | `setTappRegistry(newRegistry)` | TappRegistry 重新部署后用来切换指向;ack 状态从新 registry 读 |
 | `tappRegistry()` / `domainSeparator()` / `LOCK_TIME()` | view |
 
-**事件:** `Deposited`、`RefundRequested`、`RefundWithdrawn`、`VoucherSettled`、`EarningsWithdrawn`、`ServiceUpdated`、`ServiceDeregistered`、`OwnershipTransferred`、`TappRegistryUpdated`。
+**事件:** `Deposited`、`RefundRequested`、`RefundWithdrawn`、`VoucherSettled`、`EarningsWithdrawn`、`ServiceUpdated`、`ServiceDeregistered`、`ProviderAuthorized`、`ProviderRevoked`、`OwnershipTransferred`、`TappRegistryUpdated`。
 
 ---
 
@@ -241,3 +244,4 @@ PROVIDER_KEY=0x<provider-key> go run ./cmd/provider/ register \
 - **结算开放** — `settleFeesWithTEE` 任何人可调用，provider 由 voucher 内的 `v.provider` 字段标识，与 `msg.sender` 无关
 - **Trust root 委托** — SandboxServing 只持有商业条款；TEE 签名身份与用户 acknowledgement 都在 TappRegistry 中，每次 voucher 验签都会查询
 - **`appId` 写一次** — 一旦 `addOrUpdateService` 绑定了非空 `appId`，之后只能就地修改 URL / 价格 / createFee，无法替换 trust root。要绑定**不同的** `appId`,需先调 **`deregisterService`**:软清除调用者自己的 service 条目(url/appId/价格/createFee),但保留用户余额、待退款、已结算 nonce 和累计 `providerEarnings`(仍可提取),然后重新 register。触发 `ServiceDeregistered(provider)` 事件。
+- **Provider 委托** — 一个 appId 可以由多个钱包分别运营:app owner 调 `authorizeProvider(appId, wallet)` 授权,每个委托方注册自己的 service 条目,余额、nonce、earnings 完全隔离(与自注册 provider 同构)。余额**刻意不共享**:各自独立部署的 billing proxy 用各自的 Redis 做预留准入,互相看不见对方的在途预留,共享链上余额会导致超卖。注意结算边界是 appId 级而非委托方级:该 appId 的任何在册 TappRegistry 节点都能给任何委托方的 voucher 签名,实践中靠代码指纹(attested compose/镜像哈希)保证节点只给自己的 `PROVIDER_ADDRESS` 出账。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -51,7 +51,9 @@ PROVIDER_KEY=0x<hex> go run ./cmd/provider/ register \
 | `--chain-id` | `16602` | Chain ID |
 | `--contract` | deployed testnet addr | Settlement contract (BeaconProxy) address |
 
-The contract verifies on call: `tap.getAppInfo(appId).owner == msg.sender` and
+The contract verifies on call: `tap.getAppInfo(appId).owner == msg.sender`
+**or** `authorizedProviders[appId][msg.sender] == true` (see
+[`authorize-provider`](#authorize-provider--revoke-provider)), and
 `tap.isAuthorizedInvalidator(appId, address(this)) == true`. Stake is not
 collected here — TappRegistry holds per-node stake.
 
@@ -93,6 +95,54 @@ Done. Provider address: 0xea69...1837
 ```
 
 > **After calling `register`**: set `PROVIDER_ADDRESS` in your `.env`, then redeploy the billing service.
+
+---
+
+### `authorize-provider` / `revoke-provider`
+
+Delegate commercial service management for an appId to another wallet, or
+revoke a previous delegation. Both are signed by the **app owner's** key (the
+appId's TappRegistry owner) — not the delegate's.
+
+A delegated wallet can then call [`register`](#register--init-service) with the
+same `--app-id` and gets its **own fully isolated** service entry: separate
+URL/pricing, separate user balances, separate voucher nonces, separate
+earnings. This lets one appId (one attested app) be operated by multiple
+provider wallets — e.g. one wallet per machine — without sharing the app
+owner's key.
+
+```bash
+# Delegate (app owner signs):
+PROVIDER_KEY=0x<app-owner-hex> go run ./cmd/provider/ authorize-provider \
+  --app-id   <tapp-app-id> \
+  --provider 0x<delegate-wallet> \
+  [--rpc <rpc-url>] [--chain-id <chain-id>] [--contract <proxy-address>]
+
+# Revoke:
+PROVIDER_KEY=0x<app-owner-hex> go run ./cmd/provider/ revoke-provider \
+  --app-id   <tapp-app-id> \
+  --provider 0x<delegate-wallet>
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--key` | `PROVIDER_KEY` env | **App owner** private key — must be `tap.getAppInfo(appId).owner` |
+| `--app-id` | (required) | TappRegistry appId to delegate |
+| `--provider` | (required) | Delegate wallet address |
+| `--contract` | `SETTLEMENT_CONTRACT` env | Settlement contract (BeaconProxy) address |
+
+Semantics to be aware of:
+
+- **Revocation is soft**: it only blocks further `register` calls from the
+  delegate. Its existing service entry, user balances, nonces, earnings, and
+  settlement keep working. To cut off a delegate's ability to *sign vouchers*,
+  remove its machine as a TappRegistry node (`tapp-cli remove-node-onchain`) —
+  that is the real settlement security boundary.
+- Any delegate changing prices/createFee via `register` bumps
+  `ackVersion(appId)` in TappRegistry — **all** users of the appId (including
+  users of other delegates) must re-acknowledge before further vouchers settle.
+- Delegation state is on-chain and public: `authorizedProviders(appId, wallet)`
+  on the settlement contract; `ProviderAuthorized`/`ProviderRevoked` events.
 
 ---
 


### PR DESCRIPTION
## Summary

#56 shipped the contract + ABI + bindings + CLI subcommands but no docs. This fills the gap:

- **docs/CLI.md** — new `authorize-provider` / `revoke-provider` section (flags, examples, soft-revoke semantics, ack-invalidation warning); `register`'s ownership-check description updated to mention delegates
- **contracts/README.md / README.zh.md** — interface tables gain the three new entries + two events; Design Notes explain why delegate balances are deliberately isolated (overcommit race) and that the settlement boundary is per-appId, not per-delegate
- **CLAUDE.md** — cmd/provider directory line mentions delegation

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)