### PR TITLE
docs(skill): new-domain checklist + testnet domain rename

### DIFF
--- a/.claude/skills/0g-private-sandbox-provider/SKILL.md
+++ b/.claude/skills/0g-private-sandbox-provider/SKILL.md
@@ -254,6 +254,29 @@ State: `pending` → `active` in ~30s. Standard base snapshots to offer users:
 
 ---
 
+## New Provider Domain Checklist
+
+Setting up a domain for a provider is a MANUAL infra ritual (DNS/LB/certs live
+outside the deploy tooling). Five items — miss any and a whole feature dies
+silently (verified the hard way, 2026-07-20):
+
+1. Apex `domain` → `<host>:8082` (billing API + dashboard)
+2. **Wildcard `*.domain` → `<host>:4000`** (daytona proxy; preserve Host
+   header, WebSocket upgrade) — powers port previews (`8000-<id>.domain`)
+3. Wildcard TLS certificate covering `*.domain`
+4. TCP 2222 forwarding (SSH gateway); then set `SSH_GATEWAY_HOST=<domain>`
+5. **All records DNS-only (grey cloud)** — Cloudflare proxying (orange) blocks
+   server-to-server calls (the broker health check gets WAF 403 → "offline")
+
+Acceptance probe after wiring:
+```bash
+curl -s https://8000-test.<domain>/ | head -c 100
+# "dex/auth" redirect = wildcard routing OK; "Welcome to OpenResty!" = rule missing
+```
+Domain/env changes alter volumesHash → users must re-acknowledge; batch them.
+
+---
+
 ## Resource Quotas (oversell control)
 
 Two independent layers (both verified live):
@@ -361,3 +384,5 @@ owner and the node's TappRegistry state (active/stake).
 | Snapshot stays `pending` | Daytona can't pull the image | registry:6000 reachable? tag must not be `:latest` |
 | Everyone can create unlimited sandboxes | Org quota not enforced | See Resource Quotas — `enforceQuotas` + region_quota row |
 | SSH shows IP instead of domain | `SSH_GATEWAY_HOST` set to IP | Set it to the domain (confirm the LB forwards :2222 first) |
+| Broker frontend shows provider "offline" | Broker's server-side health check blocked: Cloudflare orange-cloud WAF 403, or container DNS can't resolve a fresh domain | Grey-cloud the DNS record (or WAF-whitelist the broker IP); fresh domains: wait out propagation |
+| Port preview URL shows an OpenResty/nginx default page | Wildcard `*.domain` traffic not forwarded to the daytona proxy | Add the wildcard→4000 rule (see New Provider Domain Checklist) |

--- a/.claude/skills/0g-private-sandbox/SKILL.md
+++ b/.claude/skills/0g-private-sandbox/SKILL.md
@@ -146,7 +146,7 @@ The command scans the chain and prints available providers with their URL, prici
 
 ```
 [1] 0xf982279B872B9a99d64C547a0faC2Dfdfc2AEE5D
-    URL:        https://provider-private-sandbox-testnet.0g.ai
+    URL:        https://provider-private-sandbox.0g.ai
     Create fee: 0.0600 0G
     CPU price:  0.001000 0G/CPU/min
     Mem price:  0.000500 0G/GB/min
@@ -282,7 +282,7 @@ If the provider has `PROXY_DOMAIN` configured, user-defined service ports are re
 The protocol matches the provider's setup (the hosted testnet uses **https**).
 For example, if a process listens on port 8000 inside the sandbox:
 ```
-https://8000-<sandboxId>.provider-private-sandbox-testnet.0g.ai/
+https://8000-<sandboxId>.provider-private-sandbox.0g.ai/
 ```
 Prefer the `preview_urls` field from the create response — it is already the
 correct protocol + domain. Requires the provider to have wildcard DNS + TLS for


### PR DESCRIPTION
今天域名切换(→ provider-private-sandbox.0g.ai)的两个 skill 跟进:

- 用户 skill:示例里的 provider 域名更新(broker 域名未变,不动)
- provider skill:新增「新开 provider 域名清单」——主域名→8082、**泛域名→4000**、泛证书、TCP 2222、**灰云直连**,附验收探针(dex 跳转 vs OpenResty 默认页);troubleshooting 增补 broker offline(橙云 WAF 403)与端口预览默认页两条

均为今天实盘踩坑的沉淀,纯文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)