### PR TITLE
chore(plugin): bump plugin version to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "0g-private-sandbox",
       "description": "Create and manage 0G Private Sandboxes from Claude Code",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "author": {
         "name": "0G Foundation"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "0g-private-sandbox",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "0G Private Sandbox — create and manage private TEE sandboxes. Includes user skill (create, manage, vibe-code) and provider skill (deploy, register, operate).",
   "author": { "name": "0G Foundation" },
   "repository": "https://github.com/0gfoundation/0g-sandbox",


### PR DESCRIPTION
Marketplace plugin version 1.0.0 → 2.0.0, ahead of the v2 (provider-is-signer) release to main — the plugin marketplace serves skills from the default branch, so installers should see a version bump alongside the rewritten skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)