### PR TITLE
fix(lifecycle): stop success-shaped failures from dropping durable state

### DIFF
--- a/cmd/billing/main.go
+++ b/cmd/billing/main.go
@@ -497,7 +497,7 @@ func main() {
 	proxyHandler.AppOwner = appOwnerFn
 	proxyHandler.RegisterPublic(apiPublic)
 	proxyHandler.Register(api)
-	go runStopHandler(ctx, stopCh, dtona, rdb, log, proxyHandler.BrokerDeregister)
+	go runStopHandler(ctx, stopCh, dtona, rdb, alerter, log, proxyHandler.BrokerDeregister)
 
 	// Admin-only: pull an image from an external registry into the internal registry.
 	// The import runs synchronously (crane.Copy) — may take minutes for large images.
@@ -857,7 +857,7 @@ func recoverPendingStops(ctx context.Context, rdb *redis.Client, stopCh chan<- s
 
 // runStopHandler consumes StopSignals, archives the sandbox (preserving state in
 // object storage so it can be restarted later), and cleans up Redis.
-func runStopHandler(ctx context.Context, stopCh <-chan settler.StopSignal, dtona *daytona.Client, rdb *redis.Client, log *zap.Logger, deregisterBroker func(context.Context, string)) {
+func runStopHandler(ctx context.Context, stopCh <-chan settler.StopSignal, dtona *daytona.Client, rdb *redis.Client, alerter alert.Alerter, log *zap.Logger, deregisterBroker func(context.Context, string)) {
 	for {
 		select {
 		case sig := <-stopCh:
@@ -880,8 +880,31 @@ func runStopHandler(ctx context.Context, stopCh <-chan settler.StopSignal, dtona
 			}
 			cancel()
 			// Step 3: archive (backup filesystem to MinIO for later restore).
+			// Only tear down billing + retry state once the sandbox is durably in
+			// a terminal archived state. If archive fails and the sandbox is NOT
+			// already archived, PRESERVE stop:sandbox:<id> so recoverPendingStops
+			// retries on the next restart — deleting it here would strand a
+			// still-running sandbox with no billing session (state drift + billing
+			// loss). An already-archived sandbox is an idempotent success, so we
+			// still clean up (avoids a poison-pill that never converges).
 			if err := dtona.ArchiveSandbox(ctx, sig.SandboxID); err != nil {
-				log.Warn("archive sandbox failed (may already be archived)",
+				if !archivedAlready(ctx, dtona, sig.SandboxID) {
+					log.Error("archive sandbox failed; preserving retry + billing state for recovery",
+						zap.String("sandbox", sig.SandboxID),
+						zap.Error(err),
+					)
+					alerter.Notify(ctx, alert.KindArchiveFailure, alert.SeverityCritical,
+						"Sandbox archive failed — retry state preserved, will retry on restart",
+						map[string]any{"sandbox": sig.SandboxID, "reason": sig.Reason, "error": err.Error()},
+					)
+					_ = events.Push(ctx, rdb, events.Event{
+						Type:      events.TypeError,
+						Message:   fmt.Sprintf("Sandbox %s archive failed: %s (retry state preserved)", sig.SandboxID, err.Error()),
+						SandboxID: sig.SandboxID,
+					})
+					continue // leave stop:sandbox:<id> + billing:compute:<id> in place
+				}
+				log.Warn("archive returned error but sandbox is already archived; proceeding to cleanup",
 					zap.String("sandbox", sig.SandboxID),
 					zap.Error(err),
 				)
@@ -904,4 +927,16 @@ func runStopHandler(ctx context.Context, stopCh <-chan settler.StopSignal, dtona
 			return
 		}
 	}
+}
+
+// archivedAlready reports whether the sandbox is already in a terminal archived
+// state — used to distinguish an idempotent re-archive (safe to clean up) from a
+// genuine archive failure (must preserve retry state). On any lookup error it
+// returns false, biasing toward preserving state.
+func archivedAlready(ctx context.Context, dtona *daytona.Client, id string) bool {
+	s, err := dtona.GetSandbox(ctx, id)
+	if err != nil || s == nil {
+		return false
+	}
+	return s.State == "archived"
 }

--- a/cmd/billing/main_test.go
+++ b/cmd/billing/main_test.go
@@ -29,36 +29,56 @@ func newTestRedis(t *testing.T) *redis.Client {
 // mockDaytona returns a test HTTP server that records which sandbox IDs were
 // stopped, and optionally injects failures for specific IDs.
 type mockDaytona struct {
-	mu      sync.Mutex
-	stopped []string
-	failIDs map[string]bool
-	srv     *httptest.Server
+	mu             sync.Mutex
+	stopped        []string
+	failIDs        map[string]bool // POST /stop → 500
+	archiveFailIDs map[string]bool // POST /archive → 500
+	archived       map[string]bool // set once archive succeeds; drives GET state
+	srv            *httptest.Server
 }
 
 func newMockDaytona(t *testing.T) *mockDaytona {
 	t.Helper()
-	m := &mockDaytona{failIDs: make(map[string]bool)}
+	m := &mockDaytona{
+		failIDs:        make(map[string]bool),
+		archiveFailIDs: make(map[string]bool),
+		archived:       make(map[string]bool),
+	}
 	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only handle POST /api/sandbox/{id}/stop
-		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/stop") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		// Extract ID: /api/sandbox/{id}/stop → parts[3]
-		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-		if len(parts) < 4 {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/") // ["api","sandbox",id,(action)]
+		if len(parts) < 3 {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		id := parts[2] // ["api","sandbox",id,"stop"]
+		id := parts[2]
 		m.mu.Lock()
 		defer m.mu.Unlock()
-		if m.failIDs[id] {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/stop"):
+			if m.failIDs[id] {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			m.stopped = append(m.stopped, id)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/archive"):
+			if m.archiveFailIDs[id] {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			m.archived[id] = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && len(parts) == 3:
+			// GetSandbox — used by WaitStopped and the archivedAlready check.
+			state := "stopped"
+			if m.archived[id] {
+				state = "archived"
+			}
+			w.Write([]byte(`{"id":"` + id + `","state":"` + state + `"}`)) //nolint:errcheck
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
-		m.stopped = append(m.stopped, id)
-		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(m.srv.Close)
 	return m
@@ -221,7 +241,7 @@ func TestRunStopHandler_StopsAndCleansRedis(t *testing.T) {
 	rdb.Set(bg, "billing:compute:sb-1", "session", 0)          //nolint:errcheck
 	rdb.Set(bg, "stop:sandbox:sb-1", "insufficient_balance", 0) //nolint:errcheck
 
-	go runStopHandler(ctx, stopCh, mock.client(), rdb, zap.NewNop(), nil)
+	go runStopHandler(ctx, stopCh, mock.client(), rdb, &noopAlerter{}, zap.NewNop(), nil)
 
 	stopCh <- settler.StopSignal{SandboxID: "sb-1", Reason: "insufficient_balance"}
 
@@ -247,7 +267,7 @@ func TestRunStopHandler_DaytonaError_StillCleansRedis(t *testing.T) {
 	rdb.Set(bg, "billing:compute:sb-err", "session", 0)    //nolint:errcheck
 	rdb.Set(bg, "stop:sandbox:sb-err", "not_acknowledged", 0) //nolint:errcheck
 
-	go runStopHandler(ctx, stopCh, mock.client(), rdb, zap.NewNop(), nil)
+	go runStopHandler(ctx, stopCh, mock.client(), rdb, &noopAlerter{}, zap.NewNop(), nil)
 
 	stopCh <- settler.StopSignal{SandboxID: "sb-err", Reason: "not_acknowledged"}
 
@@ -268,7 +288,7 @@ func TestRunStopHandler_MultipleSignals(t *testing.T) {
 		rdb.Set(bg, "stop:sandbox:"+id, "insufficient_balance", 0) //nolint:errcheck
 	}
 
-	go runStopHandler(ctx, stopCh, mock.client(), rdb, zap.NewNop(), nil)
+	go runStopHandler(ctx, stopCh, mock.client(), rdb, &noopAlerter{}, zap.NewNop(), nil)
 
 	for _, id := range []string{"sb-x", "sb-y", "sb-z"} {
 		stopCh <- settler.StopSignal{SandboxID: id, Reason: "insufficient_balance"}
@@ -296,7 +316,7 @@ func TestRunStopHandler_ContextCancel_Exits(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runStopHandler(ctx, stopCh, mock.client(), rdb, zap.NewNop(), nil)
+		runStopHandler(ctx, stopCh, mock.client(), rdb, &noopAlerter{}, zap.NewNop(), nil)
 		close(done)
 	}()
 

--- a/cmd/billing/stophandler_regression_test.go
+++ b/cmd/billing/stophandler_regression_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/0gfoundation/0g-sandbox/internal/alert"
+	"github.com/0gfoundation/0g-sandbox/internal/settler"
+	"go.uber.org/zap"
+)
+
+// noopAlerter satisfies alert.Alerter for tests and counts notifications.
+type noopAlerter struct{ count int32 }
+
+func (n *noopAlerter) Notify(ctx context.Context, kind alert.Kind, sev alert.Severity, message string, details map[string]any) {
+	atomic.AddInt32(&n.count, 1)
+}
+
+// Regression for bug-report #1: when ArchiveSandbox fails and the sandbox is NOT
+// already archived, runStopHandler must PRESERVE billing:compute:<id> and
+// stop:sandbox:<id> so recoverPendingStops can retry on restart — and alert.
+func TestStopHandler_ArchiveFailure_PreservesRetryState(t *testing.T) {
+	const id = "sb-archfail"
+	rdb := newTestRedis(t)
+	mock := newMockDaytona(t)
+	mock.archiveFailIDs[id] = true // archive 500s; sandbox never reaches "archived"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bg := context.Background()
+	rdb.Set(bg, "billing:compute:"+id, "session", 0)      //nolint:errcheck
+	rdb.Set(bg, "stop:sandbox:"+id, "insufficient_balance", 0) //nolint:errcheck
+
+	al := &noopAlerter{}
+	stopCh := make(chan settler.StopSignal, 1)
+	go runStopHandler(ctx, stopCh, mock.client(), rdb, al, zap.NewNop(), nil)
+	stopCh <- settler.StopSignal{SandboxID: id, Reason: "insufficient_balance"}
+
+	// Give the handler time to run its (failing) archive pass.
+	time.Sleep(400 * time.Millisecond)
+
+	if n, _ := rdb.Exists(bg, "stop:sandbox:"+id).Result(); n == 0 {
+		t.Errorf("stop marker deleted after archive failure — recovery can never retry")
+	}
+	if n, _ := rdb.Exists(bg, "billing:compute:"+id).Result(); n == 0 {
+		t.Errorf("billing session deleted after archive failure — billing/accounting drift")
+	}
+	if atomic.LoadInt32(&al.count) == 0 {
+		t.Errorf("expected an alert on archive failure")
+	}
+}
+
+// Companion: an already-archived sandbox is an idempotent terminal success, so a
+// failing archive call must still clean up (no poison-pill that never converges).
+func TestStopHandler_AlreadyArchived_CleansUp(t *testing.T) {
+	const id = "sb-already"
+	rdb := newTestRedis(t)
+	mock := newMockDaytona(t)
+	mock.archiveFailIDs[id] = true // archive call errors...
+	mock.archived[id] = true       // ...but sandbox is already in terminal archived state
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bg := context.Background()
+	rdb.Set(bg, "billing:compute:"+id, "session", 0)      //nolint:errcheck
+	rdb.Set(bg, "stop:sandbox:"+id, "insufficient_balance", 0) //nolint:errcheck
+
+	stopCh := make(chan settler.StopSignal, 1)
+	go runStopHandler(ctx, stopCh, mock.client(), rdb, &noopAlerter{}, zap.NewNop(), nil)
+	stopCh <- settler.StopSignal{SandboxID: id, Reason: "insufficient_balance"}
+
+	waitKeyGone(t, rdb, "stop:sandbox:"+id, time.Second)
+	waitKeyGone(t, rdb, "billing:compute:"+id, time.Second)
+}

--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -30,6 +30,8 @@ const (
 	KindVoucherRejected        Kind = "voucher_rejected"
 	KindVoucherInvalidNonce    Kind = "voucher_invalid_nonce"
 	KindQueueBacklog           Kind = "queue_backlog"
+	KindStopPersistFailure     Kind = "stop_persist_failure"
+	KindArchiveFailure         Kind = "archive_failure"
 )
 
 // Severity is included in the webhook payload so receivers can route or

--- a/internal/events/log.go
+++ b/internal/events/log.go
@@ -21,6 +21,7 @@ const (
 	TypeAutoStopped = "auto_stopped"
 	TypeSettled     = "settled"
 	TypeAggregated  = "aggregated"
+	TypeError       = "error"
 )
 
 // Event is a single operator-visible billing event stored in Redis.

--- a/internal/registry/gc.go
+++ b/internal/registry/gc.go
@@ -56,17 +56,24 @@ func ListDerivedTags(ctx context.Context, registryURL string) ([]string, error) 
 
 		tagReq, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/v2/"+repo+"/tags/list", nil)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("build tags request for repository %s: %w", repo, err)
 		}
 		tagResp, err := client.Do(tagReq)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("fetch tags for repository %s: %w", repo, err)
 		}
 		var tagList struct {
 			Tags []string `json:"tags"`
 		}
-		_ = json.NewDecoder(tagResp.Body).Decode(&tagList)
-		tagResp.Body.Close()
+		// A corrupted/truncated tag list must NOT be treated as "no tags" — that
+		// would silently skip every orphan in this repo while GC reports success.
+		decErr := json.NewDecoder(tagResp.Body).Decode(&tagList)
+		if cerr := tagResp.Body.Close(); cerr != nil && decErr == nil {
+			decErr = cerr
+		}
+		if decErr != nil {
+			return nil, fmt.Errorf("decode tags for repository %s: %w", repo, decErr)
+		}
 		for _, tag := range tagList.Tags {
 			if !strings.HasPrefix(tag, "d-") {
 				continue

--- a/internal/registry/gc_regression_test.go
+++ b/internal/registry/gc_regression_test.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression for bug-report #3: a corrupted /tags/list response must surface as
+// an error, not be silently treated as an empty tag list (which would skip every
+// orphan "d-" tag in that repo while GC reports success).
+func TestListDerivedTags_CorruptTagsList_ReturnsError(t *testing.T) {
+	// Healthy baseline: the repo has a real orphan "d-" tag and it is found.
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/_catalog":
+			w.Write([]byte(`{"repositories":["myrepo"]}`))
+		case strings.HasSuffix(r.URL.Path, "/tags/list"):
+			w.Write([]byte(`{"tags":["d-deadbeef"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer healthy.Close()
+
+	refs, err := ListDerivedTags(context.Background(), healthy.URL)
+	if err != nil {
+		t.Fatalf("healthy: unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("healthy: expected 1 orphan tag, got %v", refs)
+	}
+
+	// Corrupt: same repo, truncated JSON. Must return an error so GC fails loudly
+	// rather than silently retaining the orphan.
+	corrupt := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/_catalog":
+			w.Write([]byte(`{"repositories":["myrepo"]}`))
+		case strings.HasSuffix(r.URL.Path, "/tags/list"):
+			w.Write([]byte(`{"tags":["d-deadbe`)) // truncated / corrupt
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer corrupt.Close()
+
+	refs, err = ListDerivedTags(context.Background(), corrupt.URL)
+	if err == nil {
+		t.Fatalf("corrupt tag list must return an error, got err=nil refs=%v", refs)
+	}
+	if !strings.Contains(err.Error(), "myrepo") {
+		t.Errorf("error should name the failing repository, got: %v", err)
+	}
+}

--- a/internal/settler/handler.go
+++ b/internal/settler/handler.go
@@ -75,8 +75,13 @@ func HandleStatuses(
 						"amount":   v.TotalFee.String(),
 					},
 				)
-			} else {
-				persistStop(ctx, rdb, stopCh, sandboxID, "insufficient_balance", log)
+			} else if err := persistStop(ctx, rdb, stopCh, sandboxID, "insufficient_balance", log); err != nil {
+				log.Error("failed to persist stop marker; sandbox not queued for stop",
+					zap.String("sandbox", sandboxID), zap.Error(err))
+				alerter.Notify(ctx, alert.KindStopPersistFailure, alert.SeverityCritical,
+					"Failed to persist stop marker — sandbox will keep billing until Redis recovers",
+					map[string]any{"sandbox": sandboxID, "reason": "insufficient_balance", "error": err.Error()},
+				)
 			}
 
 		case chain.StatusNotAcknowledged:
@@ -85,8 +90,13 @@ func HandleStatuses(
 					zap.String("user", v.User.Hex()),
 					zap.String("provider", v.Provider.Hex()),
 				)
-			} else {
-				persistStop(ctx, rdb, stopCh, sandboxID, "not_acknowledged", log)
+			} else if err := persistStop(ctx, rdb, stopCh, sandboxID, "not_acknowledged", log); err != nil {
+				log.Error("failed to persist stop marker; sandbox not queued for stop",
+					zap.String("sandbox", sandboxID), zap.Error(err))
+				alerter.Notify(ctx, alert.KindStopPersistFailure, alert.SeverityCritical,
+					"Failed to persist stop marker — sandbox will keep billing until Redis recovers",
+					map[string]any{"sandbox": sandboxID, "reason": "not_acknowledged", "error": err.Error()},
+				)
 			}
 
 		case chain.StatusProviderMismatch, chain.StatusInvalidSignature:
@@ -128,12 +138,18 @@ func HandleStatuses(
 	}
 }
 
-func persistStop(ctx context.Context, rdb *redis.Client, stopCh chan<- StopSignal, sandboxID, reason string, log *zap.Logger) {
-	// 1. Persist first (crash-safe)
+func persistStop(ctx context.Context, rdb *redis.Client, stopCh chan<- StopSignal, sandboxID, reason string, log *zap.Logger) error {
+	// 1. Persist first (crash-safe). If this fails there is no recovery marker,
+	//    so we must NOT pretend the stop is queued — return the error and let the
+	//    caller alert. Signaling anyway would risk a stop with no way to recover
+	//    it after a crash.
 	stopKey := "stop:sandbox:" + sandboxID
-	rdb.Set(ctx, stopKey, reason, 0)
+	if err := rdb.Set(ctx, stopKey, reason, 0).Err(); err != nil {
+		return fmt.Errorf("persist stop marker %s: %w", stopKey, err)
+	}
 
-	// 2. Notify stop handler via channel
+	// 2. Notify stop handler via channel. Safe to drop here: the marker is
+	//    persisted, so recoverPendingStops re-queues it on restart.
 	select {
 	case stopCh <- StopSignal{SandboxID: sandboxID, Reason: reason}:
 	default:
@@ -141,6 +157,7 @@ func persistStop(ctx context.Context, rdb *redis.Client, stopCh chan<- StopSigna
 			zap.String("sandbox", sandboxID),
 		)
 	}
+	return nil
 }
 
 func extractSandboxID(v voucher.SandboxVoucher) string {

--- a/internal/settler/handler_test.go
+++ b/internal/settler/handler_test.go
@@ -342,7 +342,9 @@ func TestPersistStop_WritesKeyAndSignals(t *testing.T) {
 	stopCh := make(chan StopSignal, 2)
 	ctx := context.Background()
 
-	persistStop(ctx, rdb, stopCh, "sb-direct", "insufficient_balance", zap.NewNop())
+	if err := persistStop(ctx, rdb, stopCh, "sb-direct", "insufficient_balance", zap.NewNop()); err != nil {
+		t.Fatalf("persistStop: unexpected error: %v", err)
+	}
 
 	val, err := rdb.Get(ctx, "stop:sandbox:sb-direct").Result()
 	if err != nil || val != "insufficient_balance" {

--- a/internal/settler/persiststop_regression_test.go
+++ b/internal/settler/persiststop_regression_test.go
@@ -1,0 +1,39 @@
+package settler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// Regression for bug-report #2: persistStop must NOT signal a stop when the
+// crash-recovery marker cannot be persisted. If Redis is down it returns an
+// error and dispatches nothing, so the caller can alert instead of silently
+// stopping a sandbox with no way to recover after a crash.
+func TestPersistStop_RedisFailure_ReturnsErrorAndDoesNotSignal(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := mr.Addr()
+	rdb := redis.NewClient(&redis.Options{Addr: addr})
+
+	// Simulate Redis being unavailable at persist time.
+	mr.Close()
+
+	stopCh := make(chan StopSignal, 1)
+	err = persistStop(context.Background(), rdb, stopCh, "sbx-123", "insufficient_balance", zap.NewNop())
+
+	if err == nil {
+		t.Fatalf("expected an error when Redis persist fails, got nil")
+	}
+	select {
+	case sig := <-stopCh:
+		t.Fatalf("stop signal must NOT be dispatched when persistence failed, got %+v", sig)
+	default:
+		// correct: no signal
+	}
+}


### PR DESCRIPTION
Fixes three failure paths flagged by external code review (`0g-bug-report`, findings #1–#3). Each returned a success-shaped result while losing state that recovery depends on. All three are now fail-loud and covered by a regression test that reproduces the original bug.

## 1. Archive failure dropped retry + billing state (High)
`cmd/billing/main.go` — `runStopHandler` deleted `stop:sandbox:<id>` and `billing:compute:<id>` and logged `sandbox archived` **even when `ArchiveSandbox` failed**. `recoverPendingStops` keys off `stop:sandbox:*` on restart, so the marker's deletion made a recoverable failure permanent — a sandbox could keep running with its billing session gone (state drift / billing loss).

**Fix:** on archive failure, if the sandbox is *not* already in a terminal `archived` state, preserve both keys, push a `TypeError` event, and alert (`KindArchiveFailure`); recovery retries on the next restart. An already-archived sandbox is treated as idempotent success and still cleaned up, so a stale re-archive error can't become a poison pill that never converges.

## 2. Stop signaled even when persistence failed (Medium)
`internal/settler/handler.go` — `persistStop` was commented "Persist first (crash-safe)" but ignored the `rdb.Set` error and dispatched the stop signal regardless. A crash after signaling left no recovery marker.

**Fix:** `persistStop` returns an error; callers alert (`KindStopPersistFailure`) and do **not** signal when persistence fails.

## 3. Corrupted tag list treated as empty repo (Medium)
`internal/registry/gc.go` — per-repo request/transport/decode errors in `ListDerivedTags` were swallowed (`continue` / `_ =`). A truncated `/tags/list` looked identical to "no tags," silently skipping every orphan `d-` tag while GC reported success.

**Fix:** return an error naming the failing repository instead of silently dropping it.

## Tests
- New regression tests (fail on the old code, pass on the fix): `stophandler_regression_test.go`, `persiststop_regression_test.go`, `gc_regression_test.go`.
- Enhanced the shared mock Daytona to serve `stop` / `archive` / `get`-with-state so stop-handler tests exercise the real archive path (previously `/archive` and `GET` 404'd, which is why the old tests passed against the buggy cleanup).
- Updated existing tests for the `persistStop` error return and the `runStopHandler` signature.

`go build ./...`, `go vet`, and the affected package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)